### PR TITLE
feat: add the ability to set specific images via ZeebeClusterBuilder

### DIFF
--- a/src/main/java/io/zeebe/containers/cluster/ZeebeClusterBuilder.java
+++ b/src/main/java/io/zeebe/containers/cluster/ZeebeClusterBuilder.java
@@ -15,10 +15,11 @@
  */
 package io.zeebe.containers.cluster;
 
+import static io.zeebe.containers.ZeebeDefaults.getInstance;
+
 import io.zeebe.containers.ZeebeBrokerContainer;
 import io.zeebe.containers.ZeebeBrokerNode;
 import io.zeebe.containers.ZeebeContainer;
-import io.zeebe.containers.ZeebeDefaults;
 import io.zeebe.containers.ZeebeGatewayContainer;
 import io.zeebe.containers.ZeebeGatewayNode;
 import io.zeebe.containers.ZeebeTopologyWaitStrategy;
@@ -96,7 +97,6 @@ public class ZeebeClusterBuilder {
   private static final String BROKER_NETWORK_ALIAS_PREFIX = "zeebe-broker-";
   private static final String GATEWAY_NETWORK_ALIAS_PREFIX = "zeebe-gateway-";
   private static final String DEFAULT_CLUSTER_NAME = "zeebe-cluster";
-  private static final ZeebeDefaults ZEEBE_DEFAULTS = ZeebeDefaults.getInstance();
 
   private Network network = Network.SHARED;
   private String name = DEFAULT_CLUSTER_NAME;
@@ -107,8 +107,8 @@ public class ZeebeClusterBuilder {
   private int partitionsCount = 1;
   private int replicationFactor = 1;
   private boolean useEmbeddedGateway = true;
-  private DockerImageName gatewayImageName = ZEEBE_DEFAULTS.getDefaultDockerImage();
-  private DockerImageName brokerImageName = ZEEBE_DEFAULTS.getDefaultDockerImage();
+  private DockerImageName gatewayImageName = getInstance().getDefaultDockerImage();
+  private DockerImageName brokerImageName = getInstance().getDefaultDockerImage();
 
   private final Map<String, ZeebeGatewayNode<? extends GenericContainer<?>>> gateways =
       new HashMap<>();
@@ -279,7 +279,7 @@ public class ZeebeClusterBuilder {
    * @return this builder instance for chaining
    */
   public ZeebeClusterBuilder withImage(final DockerImageName imageName) {
-    return this.withGatewayImage(imageName).withBrokerImage(imageName);
+    return withGatewayImage(imageName).withBrokerImage(imageName);
   }
 
   /**

--- a/src/main/java/io/zeebe/containers/cluster/ZeebeClusterBuilder.java
+++ b/src/main/java/io/zeebe/containers/cluster/ZeebeClusterBuilder.java
@@ -18,6 +18,7 @@ package io.zeebe.containers.cluster;
 import io.zeebe.containers.ZeebeBrokerContainer;
 import io.zeebe.containers.ZeebeBrokerNode;
 import io.zeebe.containers.ZeebeContainer;
+import io.zeebe.containers.ZeebeDefaults;
 import io.zeebe.containers.ZeebeGatewayContainer;
 import io.zeebe.containers.ZeebeGatewayNode;
 import io.zeebe.containers.ZeebeTopologyWaitStrategy;
@@ -31,6 +32,7 @@ import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
+import org.testcontainers.utility.DockerImageName;
 
 /**
  * Convenience class to help build Zeebe clusters.
@@ -94,6 +96,7 @@ public class ZeebeClusterBuilder {
   private static final String BROKER_NETWORK_ALIAS_PREFIX = "zeebe-broker-";
   private static final String GATEWAY_NETWORK_ALIAS_PREFIX = "zeebe-gateway-";
   private static final String DEFAULT_CLUSTER_NAME = "zeebe-cluster";
+  private static final ZeebeDefaults ZEEBE_DEFAULTS = ZeebeDefaults.getInstance();
 
   private Network network = Network.SHARED;
   private String name = DEFAULT_CLUSTER_NAME;
@@ -104,6 +107,8 @@ public class ZeebeClusterBuilder {
   private int partitionsCount = 1;
   private int replicationFactor = 1;
   private boolean useEmbeddedGateway = true;
+  private DockerImageName gatewayImageName = ZEEBE_DEFAULTS.getDefaultDockerImage();
+  private DockerImageName brokerImageName = ZEEBE_DEFAULTS.getDefaultDockerImage();
 
   private final Map<String, ZeebeGatewayNode<? extends GenericContainer<?>>> gateways =
       new HashMap<>();
@@ -243,6 +248,41 @@ public class ZeebeClusterBuilder {
   }
 
   /**
+   * Sets the docker image for separate gateways. This could be used to create a test against
+   * specific Zeebe version.
+   *
+   * @param gatewayImageName the docker image name of the Zeebe
+   * @return this builder instance for chaining
+   */
+  public ZeebeClusterBuilder withGatewayImage(final DockerImageName gatewayImageName) {
+    this.gatewayImageName = Objects.requireNonNull(gatewayImageName);
+    return this;
+  }
+
+  /**
+   * Sets the docker image for brokers with embedded gateways. This could be used to create a test
+   * against specific Zeebe version.
+   *
+   * @param brokerImageName the docker image name of the Zeebe
+   * @return this builder instance for chaining
+   */
+  public ZeebeClusterBuilder withBrokerImage(final DockerImageName brokerImageName) {
+    this.brokerImageName = Objects.requireNonNull(brokerImageName);
+    return this;
+  }
+
+  /**
+   * Sets the docker image for brokers with embedded gateways and separate gateways. This could be
+   * used to create a test against specific Zeebe version.
+   *
+   * @param imageName the docker image name of the Zeebe
+   * @return this builder instance for chaining
+   */
+  public ZeebeClusterBuilder withImage(final DockerImageName imageName) {
+    return this.withGatewayImage(imageName).withBrokerImage(imageName);
+  }
+
+  /**
    * Builds a new Zeebe cluster. Will create {@link #brokersCount} brokers (accessible later via
    * {@link ZeebeCluster#getBrokers()}) and {@link #gatewaysCount} standalone gateways (accessible
    * later via {@link ZeebeCluster#getGateways()}).
@@ -305,13 +345,13 @@ public class ZeebeClusterBuilder {
       final ZeebeBrokerNode<?> broker;
 
       if (useEmbeddedGateway) {
-        final ZeebeContainer container = new ZeebeContainer();
+        final ZeebeContainer container = new ZeebeContainer(brokerImageName);
         configureGateway(container);
 
         broker = container;
         gateways.put(String.valueOf(i), container);
       } else {
-        broker = new ZeebeBrokerContainer();
+        broker = new ZeebeBrokerContainer(brokerImageName);
       }
 
       configureBroker(broker, i);
@@ -341,7 +381,7 @@ public class ZeebeClusterBuilder {
   }
 
   private ZeebeGatewayContainer createStandaloneGateway(final String memberId) {
-    final ZeebeGatewayContainer gateway = new ZeebeGatewayContainer();
+    final ZeebeGatewayContainer gateway = new ZeebeGatewayContainer(gatewayImageName);
 
     gateway
         .withNetwork(network)

--- a/src/test/java/io/zeebe/containers/cluster/ZeebeClusterBuilderTest.java
+++ b/src/test/java/io/zeebe/containers/cluster/ZeebeClusterBuilderTest.java
@@ -24,6 +24,7 @@ import io.zeebe.containers.ZeebeGatewayNode;
 import io.zeebe.containers.ZeebeNode;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.Test;
@@ -521,9 +522,12 @@ final class ZeebeClusterBuilderTest {
     final ZeebeCluster cluster = builder.build();
 
     // then
-    final Map<String, ZeebeGatewayNode<? extends GenericContainer<?>>> gateways =
-        cluster.getGateways();
-    assertThat(gateways).hasSize(1).hasValueSatisfying(zeebeImageHasImageName(zeebeDockerImage));
+    assertThat(cluster
+      .getGateways()
+      .entrySet())
+      .as("the only gateway created has the right docker image")
+      .singleElement()
+      .satisfies(gatewayEntry -> verifyZeebeHasImageName(gatewayEntry.getValue(), zeebeDockerImage));
   }
 
   @Test
@@ -538,9 +542,12 @@ final class ZeebeClusterBuilderTest {
     final ZeebeCluster cluster = builder.build();
 
     // then
-    final Map<Integer, ZeebeBrokerNode<? extends GenericContainer<?>>> brokers =
-        cluster.getBrokers();
-    assertThat(brokers).hasSize(1).hasValueSatisfying(zeebeImageHasImageName(zeebeDockerImage));
+    assertThat(cluster
+      .getBrokers()
+      .entrySet())
+      .as("the only broker created has the right docker image")
+      .singleElement()
+      .satisfies(brokerEntry -> verifyZeebeHasImageName(brokerEntry.getValue(), zeebeDockerImage));
   }
 
   @Test
@@ -559,17 +566,24 @@ final class ZeebeClusterBuilderTest {
     final ZeebeCluster cluster = builder.build();
 
     // then
-    final Map<Integer, ZeebeBrokerNode<? extends GenericContainer<?>>> brokers =
-        cluster.getBrokers();
-    assertThat(brokers).hasSize(1).hasValueSatisfying(zeebeImageHasImageName(zeebeDockerImage));
-    final Map<String, ZeebeGatewayNode<? extends GenericContainer<?>>> gateways =
-        cluster.getGateways();
-    assertThat(gateways).hasSize(1).hasValueSatisfying(zeebeImageHasImageName(zeebeDockerImage));
+    assertThat(cluster.getBrokers().entrySet())
+      .as("the only broker created has the right docker image")
+      .singleElement()
+      .satisfies(brokerEntry -> verifyZeebeHasImageName(brokerEntry.getValue(), zeebeDockerImage));
+    assertThat(cluster.getGateways().entrySet())
+      .as("the only standalone gateway created has the right docker image")
+      .singleElement()
+      .satisfies(gatewayEntry -> verifyZeebeHasImageName(gatewayEntry.getValue(), zeebeDockerImage));
   }
 
   private Condition<ZeebeNode<? extends GenericContainer<?>>> zeebeImageHasImageName(
       final String imageName) {
     return new Condition<>(
         node -> node.getDockerImageName().equals(imageName), "Image Name Condition");
+  }
+
+  private void verifyZeebeHasImageName(final ZeebeNode<? extends GenericContainer<?>> zeebe,
+    final String imageName) {
+    assertThat(zeebe.getDockerImageName()).isEqualTo(imageName);
   }
 }

--- a/src/test/java/io/zeebe/containers/cluster/ZeebeClusterBuilderTest.java
+++ b/src/test/java/io/zeebe/containers/cluster/ZeebeClusterBuilderTest.java
@@ -25,10 +25,12 @@ import io.zeebe.containers.ZeebeNode;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
+import org.testcontainers.utility.DockerImageName;
 
 final class ZeebeClusterBuilderTest {
   @Test
@@ -505,5 +507,69 @@ final class ZeebeClusterBuilderTest {
     assertThat(cluster.getBrokers().get(0).getEnvMap())
         .as("the broker is not configured to enable the embedded gateway")
         .doesNotContainEntry("ZEEBE_BROKER_GATEWAY_ENABLE", "true");
+  }
+
+  @Test
+  void shouldSetImageNameForGateways() {
+    // given
+    final ZeebeClusterBuilder builder = new ZeebeClusterBuilder();
+    final String zeebeDockerImage = "camunda/zeebe:latest";
+
+    // when
+    final DockerImageName gatewayImageName = DockerImageName.parse(zeebeDockerImage);
+    builder.withGatewayImage(gatewayImageName).withGatewaysCount(1).withEmbeddedGateway(false);
+    final ZeebeCluster cluster = builder.build();
+
+    // then
+    final Map<String, ZeebeGatewayNode<? extends GenericContainer<?>>> gateways =
+        cluster.getGateways();
+    assertThat(gateways).hasSize(1).hasValueSatisfying(zeebeImageHasImageName(zeebeDockerImage));
+  }
+
+  @Test
+  void shouldSetImageNameForBrokers() {
+    // given
+    final ZeebeClusterBuilder builder = new ZeebeClusterBuilder();
+    final String zeebeDockerImage = "camunda/zeebe:latest";
+
+    // when
+    final DockerImageName gatewayImageName = DockerImageName.parse(zeebeDockerImage);
+    builder.withBrokerImage(gatewayImageName).withBrokersCount(1);
+    final ZeebeCluster cluster = builder.build();
+
+    // then
+    final Map<Integer, ZeebeBrokerNode<? extends GenericContainer<?>>> brokers =
+        cluster.getBrokers();
+    assertThat(brokers).hasSize(1).hasValueSatisfying(zeebeImageHasImageName(zeebeDockerImage));
+  }
+
+  @Test
+  void shouldSetImageNameForGatewaysAndBrokers() {
+    // given
+    final ZeebeClusterBuilder builder = new ZeebeClusterBuilder();
+    final String zeebeDockerImage = "camunda/zeebe:latest";
+
+    // when
+    final DockerImageName gatewayImageName = DockerImageName.parse(zeebeDockerImage);
+    builder
+        .withImage(gatewayImageName)
+        .withBrokersCount(1)
+        .withGatewaysCount(1)
+        .withEmbeddedGateway(false);
+    final ZeebeCluster cluster = builder.build();
+
+    // then
+    final Map<Integer, ZeebeBrokerNode<? extends GenericContainer<?>>> brokers =
+        cluster.getBrokers();
+    assertThat(brokers).hasSize(1).hasValueSatisfying(zeebeImageHasImageName(zeebeDockerImage));
+    final Map<String, ZeebeGatewayNode<? extends GenericContainer<?>>> gateways =
+        cluster.getGateways();
+    assertThat(gateways).hasSize(1).hasValueSatisfying(zeebeImageHasImageName(zeebeDockerImage));
+  }
+
+  private Condition<ZeebeNode<? extends GenericContainer<?>>> zeebeImageHasImageName(
+      final String imageName) {
+    return new Condition<>(
+        node -> node.getDockerImageName().equals(imageName), "Image Name Condition");
   }
 }

--- a/src/test/java/io/zeebe/containers/cluster/ZeebeClusterBuilderTest.java
+++ b/src/test/java/io/zeebe/containers/cluster/ZeebeClusterBuilderTest.java
@@ -24,7 +24,6 @@ import io.zeebe.containers.ZeebeGatewayNode;
 import io.zeebe.containers.ZeebeNode;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.Test;
@@ -522,12 +521,11 @@ final class ZeebeClusterBuilderTest {
     final ZeebeCluster cluster = builder.build();
 
     // then
-    assertThat(cluster
-      .getGateways()
-      .entrySet())
-      .as("the only gateway created has the right docker image")
-      .singleElement()
-      .satisfies(gatewayEntry -> verifyZeebeHasImageName(gatewayEntry.getValue(), zeebeDockerImage));
+    assertThat(cluster.getGateways().entrySet())
+        .as("the only gateway created has the right docker image")
+        .singleElement()
+        .satisfies(
+            gatewayEntry -> verifyZeebeHasImageName(gatewayEntry.getValue(), zeebeDockerImage));
   }
 
   @Test
@@ -542,12 +540,11 @@ final class ZeebeClusterBuilderTest {
     final ZeebeCluster cluster = builder.build();
 
     // then
-    assertThat(cluster
-      .getBrokers()
-      .entrySet())
-      .as("the only broker created has the right docker image")
-      .singleElement()
-      .satisfies(brokerEntry -> verifyZeebeHasImageName(brokerEntry.getValue(), zeebeDockerImage));
+    assertThat(cluster.getBrokers().entrySet())
+        .as("the only broker created has the right docker image")
+        .singleElement()
+        .satisfies(
+            brokerEntry -> verifyZeebeHasImageName(brokerEntry.getValue(), zeebeDockerImage));
   }
 
   @Test
@@ -567,13 +564,15 @@ final class ZeebeClusterBuilderTest {
 
     // then
     assertThat(cluster.getBrokers().entrySet())
-      .as("the only broker created has the right docker image")
-      .singleElement()
-      .satisfies(brokerEntry -> verifyZeebeHasImageName(brokerEntry.getValue(), zeebeDockerImage));
+        .as("the only broker created has the right docker image")
+        .singleElement()
+        .satisfies(
+            brokerEntry -> verifyZeebeHasImageName(brokerEntry.getValue(), zeebeDockerImage));
     assertThat(cluster.getGateways().entrySet())
-      .as("the only standalone gateway created has the right docker image")
-      .singleElement()
-      .satisfies(gatewayEntry -> verifyZeebeHasImageName(gatewayEntry.getValue(), zeebeDockerImage));
+        .as("the only standalone gateway created has the right docker image")
+        .singleElement()
+        .satisfies(
+            gatewayEntry -> verifyZeebeHasImageName(gatewayEntry.getValue(), zeebeDockerImage));
   }
 
   private Condition<ZeebeNode<? extends GenericContainer<?>>> zeebeImageHasImageName(
@@ -582,8 +581,8 @@ final class ZeebeClusterBuilderTest {
         node -> node.getDockerImageName().equals(imageName), "Image Name Condition");
   }
 
-  private void verifyZeebeHasImageName(final ZeebeNode<? extends GenericContainer<?>> zeebe,
-    final String imageName) {
+  private void verifyZeebeHasImageName(
+      final ZeebeNode<? extends GenericContainer<?>> zeebe, final String imageName) {
     assertThat(zeebe.getDockerImageName()).isEqualTo(imageName);
   }
 }


### PR DESCRIPTION
## Description

I've added the convenience methods to set a docker image for the Zeebe container in the cluster.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #139 

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
- [ ] Ensure all PR checks are green
