### PR TITLE
feat: add the ability to set specific standalone gateway's envs via ZeebeClusterBuilder

### DIFF
--- a/src/main/java/io/zeebe/containers/cluster/ZeebeClusterBuilder.java
+++ b/src/main/java/io/zeebe/containers/cluster/ZeebeClusterBuilder.java
@@ -22,6 +22,7 @@ import io.zeebe.containers.ZeebeGatewayContainer;
 import io.zeebe.containers.ZeebeGatewayNode;
 import io.zeebe.containers.ZeebeTopologyWaitStrategy;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -104,6 +105,7 @@ public class ZeebeClusterBuilder {
   private int partitionsCount = 1;
   private int replicationFactor = 1;
   private boolean useEmbeddedGateway = true;
+  private Map<String, String> gatewayEnvs = Collections.emptyMap();
 
   private final Map<String, ZeebeGatewayNode<? extends GenericContainer<?>>> gateways =
       new HashMap<>();
@@ -243,6 +245,17 @@ public class ZeebeClusterBuilder {
   }
 
   /**
+   * Sets additional environment variables for the standalone gateways in the cluster.
+   *
+   * @param envs the environment map
+   * @return this builder instance for chaining
+   */
+  public ZeebeClusterBuilder withStandaloneGatewayEnvs(final Map<String, String> envs) {
+    this.gatewayEnvs = Objects.requireNonNull(envs);
+    return this;
+  }
+
+  /**
    * Builds a new Zeebe cluster. Will create {@link #brokersCount} brokers (accessible later via
    * {@link ZeebeCluster#getBrokers()}) and {@link #gatewaysCount} standalone gateways (accessible
    * later via {@link ZeebeCluster#getGateways()}).
@@ -348,7 +361,8 @@ public class ZeebeClusterBuilder {
         .withNetworkAliases(memberId)
         .withEnv("ZEEBE_GATEWAY_CLUSTER_CLUSTERNAME", name)
         .withEnv("ZEEBE_GATEWAY_CLUSTER_HOST", gateway.getInternalHost())
-        .withEnv("ZEEBE_GATEWAY_CLUSTER_MEMBERID", memberId);
+        .withEnv("ZEEBE_GATEWAY_CLUSTER_MEMBERID", memberId)
+        .withEnv(gatewayEnvs);
 
     configureGateway(gateway);
     gateways.put(memberId, gateway);

--- a/src/test/java/io/zeebe/containers/cluster/ZeebeClusterBuilderTest.java
+++ b/src/test/java/io/zeebe/containers/cluster/ZeebeClusterBuilderTest.java
@@ -22,9 +22,12 @@ import static org.assertj.core.api.Assertions.entry;
 import io.zeebe.containers.ZeebeBrokerNode;
 import io.zeebe.containers.ZeebeGatewayNode;
 import io.zeebe.containers.ZeebeNode;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
@@ -505,5 +508,28 @@ final class ZeebeClusterBuilderTest {
     assertThat(cluster.getBrokers().get(0).getEnvMap())
         .as("the broker is not configured to enable the embedded gateway")
         .doesNotContainEntry("ZEEBE_BROKER_GATEWAY_ENABLE", "true");
+  }
+
+  @Test
+  void shouldSetEnvironmentVariablesForStandaloneGateway() {
+    // given
+    final ZeebeClusterBuilder builder = new ZeebeClusterBuilder();
+    final String environmentVariable = "ZEEBE_GATEWAY_MONITORING_ENABLED";
+
+    // when
+    builder
+        .withEmbeddedGateway(false)
+        .withBrokersCount(1)
+        .withGatewaysCount(1)
+        .withStandaloneGatewayEnvs(Collections.singletonMap(environmentVariable, "true"));
+    final ZeebeCluster cluster = builder.build();
+
+    assertThat(cluster.getGateways())
+        .hasSize(1)
+        .hasValueSatisfying(
+            new Condition<>(
+                zeebeGatewayNode ->
+                    Objects.equals(zeebeGatewayNode.getEnvMap().get(environmentVariable), "true"),
+                "has specified environment variables"));
   }
 }


### PR DESCRIPTION
## Description

I've added the method in `ZeebeClusterBuilder` to set some envs to standalone gateway

## Related issues

closes #140

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
- [ ] Ensure all PR checks are green
