### PR TITLE
feat: add methods to configure gateways, brokers or both in the cluster

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>camunda-release-parent</artifactId>
     <version>3.9.1</version>
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
-    <relativePath />
+    <relativePath/>
   </parent>
 
   <groupId>io.zeebe</groupId>
@@ -352,7 +352,7 @@
               <goal>check</goal>
             </goals>
             <phase>validate</phase>
-            <configuration />
+            <configuration/>
           </execution>
         </executions>
       </plugin>
@@ -422,7 +422,7 @@
             </goals>
             <configuration>
               <rules>
-                <banDuplicatePomDependencyVersions />
+                <banDuplicatePomDependencyVersions/>
               </rules>
             </configuration>
           </execution>

--- a/src/main/java/io/zeebe/containers/cluster/ZeebeClusterBuilder.java
+++ b/src/main/java/io/zeebe/containers/cluster/ZeebeClusterBuilder.java
@@ -289,8 +289,8 @@ public class ZeebeClusterBuilder {
   }
 
   /**
-   * Sets the configuration function that will be executed lately in the {@link #build()} method on
-   * both brokers and gateways (embedded gateways included). NOTE: this configuration has the lowest
+   * Sets the configuration function that will be executed in the {@link #build()} method on both
+   * brokers and gateways (embedded gateways included). NOTE: this configuration has the lowest
    * priority, e.g. other configurations ({@link #gatewayConfig} or {@link #brokerConfig}) will
    * override this configuration in case of conflicts.
    *
@@ -303,9 +303,9 @@ public class ZeebeClusterBuilder {
   }
 
   /**
-   * Sets the configuration function that will be executed lately in the {@link #build()} method on
-   * each gateway (including embedded gateways). NOTE: in case of conflicts with {@link #nodeConfig}
-   * this configuration will override {@link #nodeConfig}. NOTE: in case of conflicts with this
+   * Sets the configuration function that will be executed in the {@link #build()} method on each
+   * gateway (including embedded gateways). NOTE: in case of conflicts with {@link #nodeConfig} this
+   * configuration will override {@link #nodeConfig}. NOTE: in case of conflicts with this
    * configuration is an embedded gateway configuration and a broker configuration, broker
    * configuration will override this configuration.
    *
@@ -320,8 +320,8 @@ public class ZeebeClusterBuilder {
   }
 
   /**
-   * Sets the configuration function that will be executed lately in the {@link #build()} method on
-   * each broker. NOTE: in case of conflicts with {@link #nodeConfig} or {@link #gatewayConfig} this
+   * Sets the configuration function that will be executed in the {@link #build()} method on each
+   * broker. NOTE: in case of conflicts with {@link #nodeConfig} or {@link #gatewayConfig} this
    * configuration will override them.
    *
    * @param brokerCfgFunction the function that will be applied on all cluster brokers

--- a/src/main/java/io/zeebe/containers/cluster/ZeebeClusterBuilder.java
+++ b/src/main/java/io/zeebe/containers/cluster/ZeebeClusterBuilder.java
@@ -112,9 +112,9 @@ public class ZeebeClusterBuilder {
   private DockerImageName gatewayImageName = getInstance().getDefaultDockerImage();
   private DockerImageName brokerImageName = getInstance().getDefaultDockerImage();
 
-  private Consumer<ZeebeNode<?>> nodeCfgFunction = cfg -> {};
-  private Consumer<ZeebeBrokerNode<?>> brokerCfgFunction = cfg -> {};
-  private Consumer<ZeebeGatewayNode<?>> gatewayCfgFunction = cfg -> {};
+  private Consumer<ZeebeNode<?>> nodeConfig = cfg -> {};
+  private Consumer<ZeebeBrokerNode<?>> brokerConfig = cfg -> {};
+  private Consumer<ZeebeGatewayNode<?>> gatewayConfig = cfg -> {};
 
   private final Map<String, ZeebeGatewayNode<? extends GenericContainer<?>>> gateways =
       new HashMap<>();
@@ -288,19 +288,20 @@ public class ZeebeClusterBuilder {
     return withGatewayImage(imageName).withBrokerImage(imageName);
   }
 
-  public ZeebeClusterBuilder withNodeCfg(final Consumer<ZeebeNode<?>> nodeCfgFunction) {
-    this.nodeCfgFunction = nodeCfgFunction;
+  public ZeebeClusterBuilder withNodeConfig(final Consumer<ZeebeNode<?>> nodeCfgFunction) {
+    this.nodeConfig = nodeCfgFunction;
     return this;
   }
 
-  public ZeebeClusterBuilder withGatewayCfg(
+  public ZeebeClusterBuilder withGatewayConfig(
       final Consumer<ZeebeGatewayNode<?>> gatewayCfgFunction) {
-    this.gatewayCfgFunction = gatewayCfgFunction;
+    this.gatewayConfig = gatewayCfgFunction;
     return this;
   }
 
-  public ZeebeClusterBuilder withBrokerCfg(final Consumer<ZeebeBrokerNode<?>> brokerCfgFunction) {
-    this.brokerCfgFunction = brokerCfgFunction;
+  public ZeebeClusterBuilder withBrokerConfig(
+      final Consumer<ZeebeBrokerNode<?>> brokerCfgFunction) {
+    this.brokerConfig = brokerCfgFunction;
     return this;
   }
 
@@ -376,8 +377,8 @@ public class ZeebeClusterBuilder {
         gateways.put(String.valueOf(i), container);
       } else {
         broker = new ZeebeBrokerContainer(brokerImageName);
-        nodeCfgFunction.accept(broker);
-        brokerCfgFunction.accept(broker);
+        nodeConfig.accept(broker);
+        brokerConfig.accept(broker);
       }
 
       configureBroker(broker, i);
@@ -428,8 +429,8 @@ public class ZeebeClusterBuilder {
                 .forBrokersCount(brokersCount)
                 .forPartitionsCount(partitionsCount)
                 .forReplicationFactor(replicationFactor));
-    nodeCfgFunction.accept(gatewayContainer);
-    gatewayCfgFunction.accept(gatewayContainer);
+    nodeConfig.accept(gatewayContainer);
+    gatewayConfig.accept(gatewayContainer);
   }
 
   private void configureBroker(final ZeebeBrokerNode<?> broker, final int index) {
@@ -446,8 +447,8 @@ public class ZeebeClusterBuilder {
             .withEnv("ZEEBE_BROKER_CLUSTER_REPLICATIONFACTOR", String.valueOf(replicationFactor))
             .withEnv("ZEEBE_BROKER_CLUSTER_PARTITIONSCOUNT", String.valueOf(partitionsCount))
             .withStartupTimeout(Duration.ofMinutes((long) brokersCount + gatewaysCount));
-    nodeCfgFunction.accept(broker);
-    brokerCfgFunction.accept(broker);
+    nodeConfig.accept(broker);
+    brokerConfig.accept(broker);
   }
 
   private void configureBrokerInitialContactPoints() {

--- a/src/main/java/io/zeebe/containers/cluster/ZeebeClusterBuilder.java
+++ b/src/main/java/io/zeebe/containers/cluster/ZeebeClusterBuilder.java
@@ -288,17 +288,45 @@ public class ZeebeClusterBuilder {
     return withGatewayImage(imageName).withBrokerImage(imageName);
   }
 
+  /**
+   * Sets the configuration function that will be executed lately in the {@link #build()} method on
+   * both brokers and gateways (embedded gateways included). NOTE: this configuration has the lowest
+   * priority, e.g. other configurations ({@link #gatewayConfig} or {@link #brokerConfig}) will
+   * override this configuration in case of conflicts.
+   *
+   * @param nodeCfgFunction the function that will be applied on all cluster nodes
+   * @return this builder instance for chaining
+   */
   public ZeebeClusterBuilder withNodeConfig(final Consumer<ZeebeNode<?>> nodeCfgFunction) {
     this.nodeConfig = nodeCfgFunction;
     return this;
   }
 
+  /**
+   * Sets the configuration function that will be executed lately in the {@link #build()} method on
+   * each gateway (including embedded gateways). NOTE: in case of conflicts with {@link #nodeConfig}
+   * this configuration will override {@link #nodeConfig}. NOTE: in case of conflicts with this
+   * configuration is an embedded gateway configuration and a broker configuration, broker
+   * configuration will override this configuration.
+   *
+   * @param gatewayCfgFunction the function that will be applied on all cluster gateways (embedded
+   *     ones included)
+   * @return this builder instance for chaining
+   */
   public ZeebeClusterBuilder withGatewayConfig(
       final Consumer<ZeebeGatewayNode<?>> gatewayCfgFunction) {
     this.gatewayConfig = gatewayCfgFunction;
     return this;
   }
 
+  /**
+   * Sets the configuration function that will be executed lately in the {@link #build()} method on
+   * each broker. NOTE: in case of conflicts with {@link #nodeConfig} or {@link #gatewayConfig} this
+   * configuration will override them.
+   *
+   * @param brokerCfgFunction the function that will be applied on all cluster brokers
+   * @return this builder instance for chaining
+   */
   public ZeebeClusterBuilder withBrokerConfig(
       final Consumer<ZeebeBrokerNode<?>> brokerCfgFunction) {
     this.brokerConfig = brokerCfgFunction;

--- a/src/test/java/io/zeebe/containers/cluster/ZeebeClusterBuilderTest.java
+++ b/src/test/java/io/zeebe/containers/cluster/ZeebeClusterBuilderTest.java
@@ -528,29 +528,25 @@ final class ZeebeClusterBuilderTest {
     // then
     assertThat(cluster.getBrokers())
         .as(
-            String.format(
-                "all brokers must have %s environment variable, e.g. must be configured by function",
-                foreseeEnv))
+            "all brokers must have %s environment variable, e.g. must be configured by function",
+            foreseeEnv)
         .allSatisfy(
             (integer, zeebeBrokerNode) ->
                 assertThat(zeebeBrokerNode.getEnvMap())
                     .as(
-                        String.format(
-                            "Broker node: %s must have %s environment variable",
-                            zeebeBrokerNode, foreseeEnv))
+                        "Broker node: %s must have %s environment variable",
+                        zeebeBrokerNode, foreseeEnv)
                     .containsKey(foreseeEnv));
     assertThat(cluster.getGateways())
         .as(
-            String.format(
-                "all gateways must not have %s environment variable, e.g. must not configured by function",
-                foreseeEnv))
+            "all gateways must not have %s environment variable, e.g. must not configured by function",
+            foreseeEnv)
         .allSatisfy(
             (s, zeebeGatewayNode) ->
                 assertThat(zeebeGatewayNode.getEnvMap())
                     .as(
-                        String.format(
-                            "Gateway node: %s must not have %s environment variable",
-                            zeebeGatewayNode, foreseeEnv))
+                        "Gateway node: %s must not have %s environment variable",
+                        zeebeGatewayNode, foreseeEnv)
                     .doesNotContainKey(foreseeEnv));
   }
 
@@ -571,29 +567,25 @@ final class ZeebeClusterBuilderTest {
     // then
     assertThat(cluster.getBrokers())
         .as(
-            String.format(
-                "all brokers must have %s environment variable, e.g. configured by function",
-                foreseeEnv))
+            "all brokers must have %s environment variable, e.g. configured by function",
+            foreseeEnv)
         .allSatisfy(
             (integer, zeebeBrokerNode) ->
                 assertThat(zeebeBrokerNode.getEnvMap())
                     .as(
-                        String.format(
-                            "Broker node: %s must have %s environment variable",
-                            zeebeBrokerNode, foreseeEnv))
+                        "Broker node: %s must have %s environment variable",
+                        zeebeBrokerNode, foreseeEnv)
                     .containsKey(foreseeEnv));
     assertThat(cluster.getGateways())
         .as(
-            String.format(
-                "all gateways must have %s environment variable, e.g. configured by function",
-                foreseeEnv))
+            "all gateways must have %s environment variable, e.g. configured by function",
+            foreseeEnv)
         .allSatisfy(
             (integer, zeebeGatewayNode) ->
                 assertThat(zeebeGatewayNode.getEnvMap())
                     .as(
-                        String.format(
-                            "Gateway node: %s must have %s environment variable",
-                            zeebeGatewayNode, foreseeEnv))
+                        "Gateway node: %s must have %s environment variable",
+                        zeebeGatewayNode, foreseeEnv)
                     .containsKey(foreseeEnv));
   }
 
@@ -614,29 +606,25 @@ final class ZeebeClusterBuilderTest {
     // then
     assertThat(cluster.getBrokers())
         .as(
-            String.format(
-                "all brokers must have %s environment variable, e.g. must be configured by function because they are have embedded gateways",
-                foreseeEnv))
+            "all brokers must have %s environment variable, e.g. must be configured by function because they are have embedded gateways",
+            foreseeEnv)
         .allSatisfy(
             (integer, zeebeBrokerNode) ->
                 assertThat(zeebeBrokerNode.getEnvMap())
                     .as(
-                        String.format(
-                            "Broker node: %s must have %s environment variable",
-                            zeebeBrokerNode, foreseeEnv))
+                        "Broker node: %s must have %s environment variable",
+                        zeebeBrokerNode, foreseeEnv)
                     .containsKey(foreseeEnv));
     assertThat(cluster.getGateways())
         .as(
-            String.format(
-                "all gateways must have %s environment variable, e.g. must be configured by function",
-                foreseeEnv))
+            "all gateways must have %s environment variable, e.g. must be configured by function",
+            foreseeEnv)
         .allSatisfy(
             (s, zeebeGatewayNode) ->
                 assertThat(zeebeGatewayNode.getEnvMap())
                     .as(
-                        String.format(
-                            "Gateway node: %s must have %s environment variable",
-                            zeebeGatewayNode, foreseeEnv))
+                        "Gateway node: %s must have %s environment variable",
+                        zeebeGatewayNode, foreseeEnv)
                     .containsKey(foreseeEnv));
   }
 
@@ -657,29 +645,25 @@ final class ZeebeClusterBuilderTest {
     // then
     assertThat(cluster.getBrokers())
         .as(
-            String.format(
-                "all brokers must not have %s environment variable, e.g. must not be configured by function",
-                foreseeEnv))
+            "all brokers must not have %s environment variable, e.g. must not be configured by function",
+            foreseeEnv)
         .allSatisfy(
             (integer, zeebeBrokerNode) ->
                 assertThat(zeebeBrokerNode.getEnvMap())
                     .as(
-                        String.format(
-                            "Broker node: %s must not have %s environment variable",
-                            zeebeBrokerNode, foreseeEnv))
+                        "Broker node: %s must not have %s environment variable",
+                        zeebeBrokerNode, foreseeEnv)
                     .doesNotContainKey(foreseeEnv));
     assertThat(cluster.getGateways())
         .as(
-            String.format(
-                "all gateways must have %s environment variable, e.g. must be configured by function",
-                foreseeEnv))
+            "all gateways must have %s environment variable, e.g. must be configured by function",
+            foreseeEnv)
         .allSatisfy(
             (s, zeebeGatewayNode) ->
                 assertThat(zeebeGatewayNode.getEnvMap())
                     .as(
-                        String.format(
-                            "Gateway node: %s must have %s environment variable",
-                            zeebeGatewayNode, foreseeEnv))
+                        "Gateway node: %s must have %s environment variable",
+                        zeebeGatewayNode, foreseeEnv)
                     .containsKey(foreseeEnv));
   }
 
@@ -704,29 +688,25 @@ final class ZeebeClusterBuilderTest {
     // then
     assertThat(cluster.getBrokers())
         .as(
-            String.format(
-                "all brokers must have %s environment variable with %s value, e.g. must be configured by broker function",
-                foreseeEnv, brokerValue))
+            "all brokers must have %s environment variable with %s value, e.g. must be configured by broker function",
+            foreseeEnv, brokerValue)
         .allSatisfy(
             (integer, zeebeBrokerNode) ->
                 assertThat(zeebeBrokerNode.getEnvMap())
                     .as(
-                        String.format(
-                            "Broker node: %s must not have %s environment variable",
-                            zeebeBrokerNode, foreseeEnv))
+                        "Broker node: %s must not have %s environment variable",
+                        zeebeBrokerNode, foreseeEnv)
                     .containsEntry(foreseeEnv, brokerValue));
     assertThat(cluster.getGateways())
         .as(
-            String.format(
-                "all gateways must have %s environment variable with %s value, e.g. must be configured by node function",
-                foreseeEnv, nodeValue))
+            "all gateways must have %s environment variable with %s value, e.g. must be configured by node function",
+            foreseeEnv, nodeValue)
         .allSatisfy(
             (s, zeebeGatewayNode) ->
                 assertThat(zeebeGatewayNode.getEnvMap())
                     .as(
-                        String.format(
-                            "Gateway node: %s must have %s environment variable",
-                            zeebeGatewayNode, foreseeEnv))
+                        "Gateway node: %s must have %s environment variable",
+                        zeebeGatewayNode, foreseeEnv)
                     .containsEntry(foreseeEnv, nodeValue));
   }
 
@@ -751,29 +731,25 @@ final class ZeebeClusterBuilderTest {
     // then
     assertThat(cluster.getBrokers())
         .as(
-            String.format(
-                "all brokers must have %s environment variable with %s value, e.g. must not be configured by gateway function",
-                foreseeEnv, gatewayValue))
+            "all brokers must have %s environment variable with %s value, e.g. must not be configured by gateway function",
+            foreseeEnv, gatewayValue)
         .allSatisfy(
             (integer, zeebeBrokerNode) ->
                 assertThat(zeebeBrokerNode.getEnvMap())
                     .as(
-                        String.format(
-                            "Broker node: %s must not have %s environment variable",
-                            zeebeBrokerNode, foreseeEnv))
+                        "Broker node: %s must not have %s environment variable",
+                        zeebeBrokerNode, foreseeEnv)
                     .containsEntry(foreseeEnv, nodeValue));
     assertThat(cluster.getGateways())
         .as(
-            String.format(
-                "all gateways must have %s environment variable with %s value, e.g. must be configured by gateway function",
-                foreseeEnv, nodeValue))
+            "all gateways must have %s environment variable with %s value, e.g. must be configured by gateway function",
+            foreseeEnv, nodeValue)
         .allSatisfy(
             (s, zeebeGatewayNode) ->
                 assertThat(zeebeGatewayNode.getEnvMap())
                     .as(
-                        String.format(
-                            "Gateway node: %s must have %s environment variable",
-                            zeebeGatewayNode, foreseeEnv))
+                        "Gateway node: %s must have %s environment variable",
+                        zeebeGatewayNode, foreseeEnv)
                     .containsEntry(foreseeEnv, gatewayValue));
   }
 
@@ -798,29 +774,25 @@ final class ZeebeClusterBuilderTest {
     // then
     assertThat(cluster.getBrokers())
         .as(
-            String.format(
-                "all brokers must have %s environment variable with %s value, e.g. must not be configured by gateway function",
-                foreseeEnv, gatewayValue))
+            "all brokers must have %s environment variable with %s value, e.g. must not be configured by gateway function",
+            foreseeEnv, gatewayValue)
         .allSatisfy(
             (integer, zeebeBrokerNode) ->
                 assertThat(zeebeBrokerNode.getEnvMap())
                     .as(
-                        String.format(
-                            "Broker node: %s must not have %s environment variable",
-                            zeebeBrokerNode, foreseeEnv))
+                        "Broker node: %s must not have %s environment variable",
+                        zeebeBrokerNode, foreseeEnv)
                     .containsEntry(foreseeEnv, brokerValue));
     assertThat(cluster.getGateways())
         .as(
-            String.format(
-                "all gateways must not have %s environment variable with %s value, e.g. must not be configured by gateway function",
-                foreseeEnv, brokerValue))
+            "all gateways must not have %s environment variable with %s value, e.g. must not be configured by gateway function",
+            foreseeEnv, brokerValue)
         .allSatisfy(
             (s, zeebeGatewayNode) ->
                 assertThat(zeebeGatewayNode.getEnvMap())
                     .as(
-                        String.format(
-                            "Gateway node: %s must have %s environment variable",
-                            zeebeGatewayNode, foreseeEnv))
+                        "Gateway node: %s must have %s environment variable",
+                        zeebeGatewayNode, foreseeEnv)
                     .doesNotContainEntry(foreseeEnv, gatewayValue));
   }
 

--- a/src/test/java/io/zeebe/containers/cluster/ZeebeClusterBuilderTest.java
+++ b/src/test/java/io/zeebe/containers/cluster/ZeebeClusterBuilderTest.java
@@ -531,9 +531,9 @@ final class ZeebeClusterBuilderTest {
 
     // when
     builder
-        .withNodeCfg(nodeCfgFunction)
-        .withBrokerCfg(brokerCfgFunction)
-        .withGatewayCfg(gatewayCfgFunction)
+        .withNodeConfig(nodeCfgFunction)
+        .withBrokerConfig(brokerCfgFunction)
+        .withGatewayConfig(gatewayCfgFunction)
         .withBrokersCount(1)
         .withGatewaysCount(1)
         .withEmbeddedGateway(false);

--- a/src/test/java/io/zeebe/containers/cluster/ZeebeClusterBuilderTest.java
+++ b/src/test/java/io/zeebe/containers/cluster/ZeebeClusterBuilderTest.java
@@ -527,9 +527,6 @@ final class ZeebeClusterBuilderTest {
 
     // then
     assertThat(cluster.getBrokers())
-        .as(
-            "all brokers must have %s environment variable, e.g. must be configured by function",
-            foreseeEnv)
         .allSatisfy(
             (integer, zeebeBrokerNode) ->
                 assertThat(zeebeBrokerNode.getEnvMap())
@@ -538,9 +535,6 @@ final class ZeebeClusterBuilderTest {
                         zeebeBrokerNode, foreseeEnv)
                     .containsKey(foreseeEnv));
     assertThat(cluster.getGateways())
-        .as(
-            "all gateways must not have %s environment variable, e.g. must not configured by function",
-            foreseeEnv)
         .allSatisfy(
             (s, zeebeGatewayNode) ->
                 assertThat(zeebeGatewayNode.getEnvMap())
@@ -566,9 +560,6 @@ final class ZeebeClusterBuilderTest {
 
     // then
     assertThat(cluster.getBrokers())
-        .as(
-            "all brokers must have %s environment variable, e.g. configured by function",
-            foreseeEnv)
         .allSatisfy(
             (integer, zeebeBrokerNode) ->
                 assertThat(zeebeBrokerNode.getEnvMap())
@@ -577,9 +568,6 @@ final class ZeebeClusterBuilderTest {
                         zeebeBrokerNode, foreseeEnv)
                     .containsKey(foreseeEnv));
     assertThat(cluster.getGateways())
-        .as(
-            "all gateways must have %s environment variable, e.g. configured by function",
-            foreseeEnv)
         .allSatisfy(
             (integer, zeebeGatewayNode) ->
                 assertThat(zeebeGatewayNode.getEnvMap())
@@ -605,9 +593,6 @@ final class ZeebeClusterBuilderTest {
 
     // then
     assertThat(cluster.getBrokers())
-        .as(
-            "all brokers must have %s environment variable, e.g. must be configured by function because they are have embedded gateways",
-            foreseeEnv)
         .allSatisfy(
             (integer, zeebeBrokerNode) ->
                 assertThat(zeebeBrokerNode.getEnvMap())
@@ -616,9 +601,6 @@ final class ZeebeClusterBuilderTest {
                         zeebeBrokerNode, foreseeEnv)
                     .containsKey(foreseeEnv));
     assertThat(cluster.getGateways())
-        .as(
-            "all gateways must have %s environment variable, e.g. must be configured by function",
-            foreseeEnv)
         .allSatisfy(
             (s, zeebeGatewayNode) ->
                 assertThat(zeebeGatewayNode.getEnvMap())
@@ -644,9 +626,6 @@ final class ZeebeClusterBuilderTest {
 
     // then
     assertThat(cluster.getBrokers())
-        .as(
-            "all brokers must not have %s environment variable, e.g. must not be configured by function",
-            foreseeEnv)
         .allSatisfy(
             (integer, zeebeBrokerNode) ->
                 assertThat(zeebeBrokerNode.getEnvMap())
@@ -655,9 +634,6 @@ final class ZeebeClusterBuilderTest {
                         zeebeBrokerNode, foreseeEnv)
                     .doesNotContainKey(foreseeEnv));
     assertThat(cluster.getGateways())
-        .as(
-            "all gateways must have %s environment variable, e.g. must be configured by function",
-            foreseeEnv)
         .allSatisfy(
             (s, zeebeGatewayNode) ->
                 assertThat(zeebeGatewayNode.getEnvMap())
@@ -687,9 +663,6 @@ final class ZeebeClusterBuilderTest {
 
     // then
     assertThat(cluster.getBrokers())
-        .as(
-            "all brokers must have %s environment variable with %s value, e.g. must be configured by broker function",
-            foreseeEnv, brokerValue)
         .allSatisfy(
             (integer, zeebeBrokerNode) ->
                 assertThat(zeebeBrokerNode.getEnvMap())
@@ -698,9 +671,6 @@ final class ZeebeClusterBuilderTest {
                         zeebeBrokerNode, foreseeEnv)
                     .containsEntry(foreseeEnv, brokerValue));
     assertThat(cluster.getGateways())
-        .as(
-            "all gateways must have %s environment variable with %s value, e.g. must be configured by node function",
-            foreseeEnv, nodeValue)
         .allSatisfy(
             (s, zeebeGatewayNode) ->
                 assertThat(zeebeGatewayNode.getEnvMap())
@@ -730,9 +700,6 @@ final class ZeebeClusterBuilderTest {
 
     // then
     assertThat(cluster.getBrokers())
-        .as(
-            "all brokers must have %s environment variable with %s value, e.g. must not be configured by gateway function",
-            foreseeEnv, gatewayValue)
         .allSatisfy(
             (integer, zeebeBrokerNode) ->
                 assertThat(zeebeBrokerNode.getEnvMap())
@@ -741,9 +708,6 @@ final class ZeebeClusterBuilderTest {
                         zeebeBrokerNode, foreseeEnv)
                     .containsEntry(foreseeEnv, nodeValue));
     assertThat(cluster.getGateways())
-        .as(
-            "all gateways must have %s environment variable with %s value, e.g. must be configured by gateway function",
-            foreseeEnv, nodeValue)
         .allSatisfy(
             (s, zeebeGatewayNode) ->
                 assertThat(zeebeGatewayNode.getEnvMap())
@@ -773,9 +737,6 @@ final class ZeebeClusterBuilderTest {
 
     // then
     assertThat(cluster.getBrokers())
-        .as(
-            "all brokers must have %s environment variable with %s value, e.g. must not be configured by gateway function",
-            foreseeEnv, gatewayValue)
         .allSatisfy(
             (integer, zeebeBrokerNode) ->
                 assertThat(zeebeBrokerNode.getEnvMap())
@@ -784,9 +745,6 @@ final class ZeebeClusterBuilderTest {
                         zeebeBrokerNode, foreseeEnv)
                     .containsEntry(foreseeEnv, brokerValue));
     assertThat(cluster.getGateways())
-        .as(
-            "all gateways must not have %s environment variable with %s value, e.g. must not be configured by gateway function",
-            foreseeEnv, brokerValue)
         .allSatisfy(
             (s, zeebeGatewayNode) ->
                 assertThat(zeebeGatewayNode.getEnvMap())

--- a/src/test/java/io/zeebe/containers/cluster/ZeebeClusterBuilderTest.java
+++ b/src/test/java/io/zeebe/containers/cluster/ZeebeClusterBuilderTest.java
@@ -25,8 +25,15 @@ import io.zeebe.containers.ZeebeNode;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
@@ -511,6 +518,40 @@ final class ZeebeClusterBuilderTest {
         .doesNotContainEntry("ZEEBE_BROKER_GATEWAY_ENABLE", "true");
   }
 
+  @ParameterizedTest
+  @ArgumentsSource(ConfigurationArguments.class)
+  void shouldConfigureGatewayAndBroker(
+      final Consumer<ZeebeNode<?>> nodeCfgFunction,
+      final Consumer<ZeebeBrokerNode<?>> brokerCfgFunction,
+      final Consumer<ZeebeGatewayNode<?>> gatewayCfgFunction,
+      final Condition<ZeebeBrokerNode<? extends GenericContainer<?>>> brokerCondition,
+      final Condition<ZeebeGatewayNode<? extends GenericContainer<?>>> gatewayNodeCondition) {
+    // given
+    final ZeebeClusterBuilder builder = new ZeebeClusterBuilder();
+
+    // when
+    builder
+        .withNodeCfg(nodeCfgFunction)
+        .withBrokerCfg(brokerCfgFunction)
+        .withGatewayCfg(gatewayCfgFunction)
+        .withBrokersCount(1)
+        .withGatewaysCount(1)
+        .withEmbeddedGateway(false);
+    final ZeebeCluster cluster = builder.build();
+
+    // then
+    assertThat(cluster.getGateways())
+        .as("there is only one gateway")
+        .hasSize(1)
+        .as("gatewayCondition")
+        .hasValueSatisfying(gatewayNodeCondition);
+    assertThat(cluster.getBrokers())
+        .as("there is only one broker")
+        .hasSize(1)
+        .as("brokerCondition")
+        .hasValueSatisfying(brokerCondition);
+  }
+
   @Test
   void shouldSetImageNameForGateways() {
     // given
@@ -586,5 +627,75 @@ final class ZeebeClusterBuilderTest {
   private void verifyZeebeHasImageName(
       final ZeebeNode<? extends GenericContainer<?>> zeebe, final String imageName) {
     assertThat(zeebe.getDockerImageName()).isEqualTo(imageName);
+  }
+
+  static class ConfigurationArguments implements ArgumentsProvider {
+
+    @Override
+    public Stream<? extends Arguments> provideArguments(final ExtensionContext extensionContext)
+        throws Exception {
+      final String nodeCfgKey = "nodeCfgKey";
+      final String brokerCfgKey = "brokerCfgKey";
+      final String gatewayCfgKey = "gatewayCfgKey";
+      final String envDescription = getDescription("all zeebe nodes", true, nodeCfgKey);
+      return Stream.of(
+          Arguments.of(
+              (Consumer<ZeebeNode<?>>) zeebeNode -> zeebeNode.addEnv(nodeCfgKey, ""),
+              (Consumer<ZeebeBrokerNode<?>>) zeebeBrokerNode -> {},
+              (Consumer<ZeebeGatewayNode<?>>) zeebeGatewayNode -> {},
+              new Condition<ZeebeBrokerNode<? extends GenericContainer<?>>>(
+                  broker -> broker.getEnvMap().containsKey(nodeCfgKey), envDescription),
+              new Condition<ZeebeGatewayNode<? extends GenericContainer<?>>>(
+                  gateway -> gateway.getEnvMap().containsKey(nodeCfgKey), envDescription)),
+          Arguments.of(
+              (Consumer<ZeebeNode<?>>) zeebeNode -> {},
+              (Consumer<ZeebeBrokerNode<?>>)
+                  zeebeBrokerNode -> zeebeBrokerNode.addEnv(brokerCfgKey, ""),
+              (Consumer<ZeebeGatewayNode<?>>) zeebeGatewayNode -> {},
+              new Condition<ZeebeBrokerNode<? extends GenericContainer<?>>>(
+                  broker -> broker.getEnvMap().containsKey(brokerCfgKey),
+                  getDescription("Broker", true, brokerCfgKey)),
+              new Condition<ZeebeGatewayNode<? extends GenericContainer<?>>>(
+                  gateway -> !gateway.getEnvMap().containsKey(brokerCfgKey),
+                  getDescription("Gateway", false, brokerCfgKey))),
+          Arguments.of(
+              (Consumer<ZeebeNode<?>>) zeebeNode -> {},
+              (Consumer<ZeebeBrokerNode<?>>) zeebeBrokerNode -> {},
+              (Consumer<ZeebeGatewayNode<?>>)
+                  zeebeGatewayNode -> zeebeGatewayNode.addEnv(gatewayCfgKey, ""),
+              new Condition<ZeebeBrokerNode<? extends GenericContainer<?>>>(
+                  broker -> !broker.getEnvMap().containsKey(gatewayCfgKey),
+                  getDescription("Broker", false, gatewayCfgKey)),
+              new Condition<ZeebeGatewayNode<? extends GenericContainer<?>>>(
+                  gateway -> gateway.getEnvMap().containsKey(gatewayCfgKey),
+                  getDescription("Gateway", true, gatewayCfgKey))),
+          Arguments.of(
+              (Consumer<ZeebeNode<?>>)
+                  zeebeNode -> {
+                    zeebeNode.addEnv(gatewayCfgKey, "2");
+                    zeebeNode.addEnv(brokerCfgKey, "2");
+                  },
+              (Consumer<ZeebeBrokerNode<?>>)
+                  zeebeBrokerNode -> zeebeBrokerNode.addEnv(brokerCfgKey, "1"),
+              (Consumer<ZeebeGatewayNode<?>>)
+                  zeebeGatewayNode -> zeebeGatewayNode.addEnv(gatewayCfgKey, "1"),
+              new Condition<ZeebeBrokerNode<? extends GenericContainer<?>>>(
+                  broker -> broker.getEnvMap().get(brokerCfgKey).equals("1"),
+                  "broker configuration should override node configuration"),
+              new Condition<ZeebeGatewayNode<? extends GenericContainer<?>>>(
+                  gateway -> gateway.getEnvMap().get(gatewayCfgKey).equals("1"),
+                  "gateway configuration should override node configuration")));
+    }
+
+    private String getDescription(
+        final String zeebeNodeName, final boolean isPositive, final String nodeCfgKey) {
+      final String verb;
+      if (isPositive) {
+        verb = "should";
+      } else {
+        verb = "should not";
+      }
+      return String.format("%s %s have %s variable", zeebeNodeName, verb, nodeCfgKey);
+    }
   }
 }


### PR DESCRIPTION
## Description

I created three methods to configure parts of the cluster: gateways, brokers, or both. I decided to use the `Consumer` interface instead of `UnaryOperator` because it is much more convenient to implement with `Consumer`.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #150 

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
- [ ] Ensure all PR checks are green
