### PR TITLE
deps: update commons-compress to 1.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
     <version.revapi>0.24.4</version.revapi>
     <version.slf4j>1.7.32</version.slf4j>
     <version.testcontainers>1.15.3</version.testcontainers>
+    <version.commons-compress>1.21</version.commons-compress>
     <version.zeebe>1.1.3</version.zeebe>
 
     <!-- plugin version -->
@@ -73,6 +74,15 @@
         <version>${version.zeebe}</version>
         <scope>import</scope>
         <type>pom</type>
+      </dependency>
+
+      <!-- We need to do this since there is a problem with
+      testcontainers 1.16.0 and this dependency:
+      https://github.com/testcontainers/testcontainers-java/issues/4384 -->
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-compress</artifactId>
+        <version>${version.commons-compress}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/revapi.json
+++ b/revapi.json
@@ -29,6 +29,10 @@
         },
         {
           "code": "java.method.addedToInterface"
+        },
+        {
+          "code": "java.class.externalClassExposedInAPI",
+          "oldArchive": "org.apache.commons:commons-compress:jar:1.21"
         }
       ]
     }
@@ -41,6 +45,27 @@
       "differences": [
         {
           "code": "java.method.addedToInterface"
+        }
+      ]
+    }
+  },
+  {
+    "extension": "revapi.differences",
+    "configuration": {
+      "differences": [
+        {
+          "ignore": true,
+          "code": "java.method.added",
+          "new": "method org.apache.commons.compress.archivers.ArchiveEntry org.apache.commons.compress.archivers.tar.TarArchiveOutputStream::createArchiveEntry(java.nio.file.Path, java.lang.String, java.nio.file.LinkOption[]) throws java.io.IOException",
+          "justification": "ADD YOUR EXPLANATION FOR THE NECESSITY OF THIS CHANGE",
+          "package": "org.apache.commons.compress.archivers.tar",
+          "classQualifiedName": "org.apache.commons.compress.archivers.tar.TarArchiveOutputStream",
+          "classSimpleName": "TarArchiveOutputStream",
+          "methodName": "createArchiveEntry",
+          "elementKind": "method",
+          "newArchive": "org.apache.commons:commons-compress:jar:1.21",
+          "newArchiveRole": "supplementary",
+          "breaksSemanticVersioning": "true"
         }
       ]
     }


### PR DESCRIPTION
## Description

Since we have an issue with vulnerabilities: https://github.com/testcontainers/testcontainers-java/issues/4384 I decided that we should update this dependency by ourselves.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #187

## Pull Request Checklist

- [X] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [X] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [X] If submitting code, please run `mvn clean install -DskipTests` locally before committing
- [ ] Ensure all PR checks are green
