### PR TITLE
Adds remote debugging utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ use containers for your tests, as well as general prerequisites.
   - [Examples](#examples)
   - [Continuous Integration](#continuous-integration)
 - [Tips](#tips)
+  - [Debugging](#debugging)
   - [Tailing your container's logs during development](#tailing-your-containers-logs-during-development)
   - [Configuring GenericContainer specific properties with a Zeebe*Node interface](#configuring-genericcontainer-specific-properties-with-a-zeebenode-interface)
   - [Advanced Docker usage via the DockerClient](#advanced-docker-usage-via-the-dockerclient)
@@ -479,6 +480,70 @@ If you wish to use this with your continous integration pipeline (e.g. Jenkins, 
 explaining how to use it, how volumes can be shared, etc.
 
 # Tips
+
+## Debugging
+
+There might be cases where you want to debug a container you just started in one of your tests. You
+can use the [RemoteDebugger](/src/main/java/io/zeebe/containers/util/RemoteDebugger.java) utility
+for this. By default, it will start your container and attach a debugging agent to it on port 5005.
+The container startup is then suspended until a debugger attaches to it.
+
+> NOTE: since the startup is suspended until a debugger connects to it, it's possible for a the
+> startup strategy to time out if no debugger connects to it.
+
+You can use it with any container as:
+
+```java
+package com.acme.zeebe;
+
+import io.zeebe.containers.ZeebeContainer;
+import io.zeebe.containers.util.RemoteDebugger;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public class MyFeatureTest {
+
+  @Container
+  private final ZeebeContainer zeebeContainer = RemoteDebugger.configure(new ZeebeContainer());
+
+  @Test
+  void shouldTestProperty() {
+    // test...
+  }
+}
+```
+
+Note that `RemoteDebugger#configure(GenericContainer<?>)` returns the same container, so you can use
+the return value to chain more configuration around your container.
+
+```java
+package com.acme.zeebe;
+
+import io.zeebe.containers.ZeebeContainer;
+import io.zeebe.containers.util.RemoteDebugger;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public class MyFeatureTest {
+
+  @Container
+  private final ZeebeContainer zeebeContainer = RemoteDebugger.configure(new ZeebeContainer())
+    .withEnv("ZEEBE_BROKER_NETWORK_HOST", "0.0.0.0");
+
+  @Test
+  void shouldTestProperty() {
+    // test...
+  }
+}
+```
+
+You can also configure the port of the debug server, or even configure the startup to not wait for a
+debugger to connect by using `RemoteDebugger#configure(GenericContainer<?>, int, boolean)`. See the
+Javadoc for more.
 
 ## Tailing your container's logs during development
 

--- a/src/main/java/io/zeebe/containers/util/RemoteDebugger.java
+++ b/src/main/java/io/zeebe/containers/util/RemoteDebugger.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2021 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.containers.util;
+
+import java.time.Duration;
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+import org.testcontainers.containers.GenericContainer;
+
+/**
+ * To use, create a new instance with the desired port (or, by default, 5005), and pass the
+ * container you wish to configure to it.
+ *
+ * <p>This will start the container and wait for the debugger to attach. To use with Intellij,
+ * create a new debug configuration template and pick "Remote JVM Debug". By default, it will be
+ * setup for port 5005, which is the default port here as well. You can find out more about this
+ * from <a href="https://www.jetbrains.com/help/idea/tutorial-remote-debug.html">this IntelliJ
+ * tutorial</a>.
+ *
+ * <p>This idea came from bsideup's blog, and you can read more about it <a
+ * href="https://bsideup.github.io/posts/debugging_containers/">here</a>
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * final ZeebeContainer container = new ZeebeContainer();
+ * RemoteDebugger.configure(container, 5005, true);
+ * }</pre>
+ *
+ * <pre>{@code
+ * @Testcontainers
+ * final class MyTest {
+ *   @Container
+ *   private final ZeebeContainer = RemoteDebugger.configure(new ZeebeContainer())
+ *       .withEnv("MY_ENV_VAR", "true");
+ *
+ *   // more test code...
+ * }
+ * }</pre>
+ */
+@API(status = Status.EXPERIMENTAL)
+public final class RemoteDebugger {
+  public static final int DEFAULT_REMOTE_DEBUGGER_PORT = 5005;
+  public static final Duration DEFAULT_START_TIMEOUT = Duration.ofMinutes(5);
+
+  private RemoteDebugger() {}
+
+  /**
+   * Returns the given container configured to start a debugging server. Uses the default port 5005.
+   * By default, the application will be suspended until a debugger connects to it.
+   *
+   * @param container the container to configure
+   * @param <T> the type of the container
+   * @return the same container configured for debugging
+   */
+  public static <T extends GenericContainer<T>> T configure(final T container) {
+    return configure(container, DEFAULT_REMOTE_DEBUGGER_PORT);
+  }
+
+  /**
+   * Returns the given container configured to start a debugging server on the given port. By
+   * default, the application will be suspended until a debugger connects to it.
+   *
+   * @param container the container to configure
+   * @param port the port to bind the debugging server to
+   * @param <T> the type of the container
+   * @return the same container configured for debugging
+   */
+  public static <T extends GenericContainer<T>> T configure(final T container, final int port) {
+    return configure(container, port, true);
+  }
+
+  /**
+   * Returns the given container configured to start a debugging server on the given port. If {@code
+   * suspend} is true, the application is suspended until a debugger instance connects to the
+   * server.
+   *
+   * @param container the container to configure
+   * @param port the port to bind the debugging server to
+   * @param suspend if true, will suspend the application until a debugger connects to it
+   * @param <T> the type of the container
+   * @return the same container configured for debugging
+   */
+  public static <T extends GenericContainer<T>> T configure(
+      final T container, final int port, boolean suspend) {
+    final String javaOpts = container.getEnvMap().getOrDefault("JAVA_OPTS", "");
+    final char suspendFlag = suspend ? 'y' : 'n';
+
+    // when configuring a port binding, we need to expose the port as well; the port binding just
+    // decides to which host port the exposed port will bind, but it will not expose the port itself
+    container.addExposedPort(port);
+    container.getPortBindings().add(port + ":" + port);
+
+    // prepend agent configuration in front of javaOpts to ensure it's enabled but also keep
+    // previously defined options
+    container.withEnv(
+        "JAVA_OPTS",
+        String.format(
+            "-agentlib:jdwp=transport=dt_socket,server=y,suspend=%s,address=0.0.0.0:%d %s",
+            suspendFlag, port, javaOpts));
+
+    return container.withStartupTimeout(DEFAULT_START_TIMEOUT);
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a new utility class, RemoteDebugger, which will configure containers to start with a debugging server attached.

Note that there are no tests, mostly because any test for this feature would be contrived I think. At least I couldn't find a simple way to test something like this in a programmatic way.

## Related issues

closes #149 

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
- [x] Ensure all PR checks are green
