### PR TITLE
Add a high level time travel API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,20 +51,21 @@
     <!-- project dependencies -->
     <version.agrona>1.14.0</version.agrona>
     <version.apiguardian>1.1.2</version.apiguardian>
-    <version.assertj>3.21.0</version.assertj>
+    <version.assertj>3.22.0</version.assertj>
     <version.awaitility>4.1.1</version.awaitility>
     <version.checkstyle>9.2</version.checkstyle>
     <version.compress>1.21</version.compress>
     <version.docker-java>3.2.12</version.docker-java>
     <version.duct-tape>1.0.8</version.duct-tape>
+    <version.feign>11.7</version.feign>
+    <version.jackson>2.13.1</version.jackson>
     <version.junit-jupiter>5.8.2</version.junit-jupiter>
     <version.junit-surefire-provider>1.3.2</version.junit-surefire-provider>
-    <version.mockito>4.1.0</version.mockito>
+    <version.mockito>4.2.0</version.mockito>
     <version.revapi>0.26.1</version.revapi>
-    <version.slf4j>1.7.32</version.slf4j>
-    <version.testcontainers>1.16.2</version.testcontainers>
-    <version.commons-compress>1.21</version.commons-compress>
-    <version.zeebe>1.2.5</version.zeebe>
+    <version.slf4j>1.7.33</version.slf4j>
+    <version.testcontainers>1.16.3</version.testcontainers>
+    <version.zeebe>1.3.1</version.zeebe>
 
     <!-- plugin version -->
     <plugin.version.checkstyle>3.1.2</plugin.version.checkstyle>
@@ -107,6 +108,14 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-bom</artifactId>
+        <version>${version.feign}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -134,16 +143,41 @@
       <scope>provided</scope>
     </dependency>
 
+    <!-- various utilities -->
     <dependency>
       <groupId>org.agrona</groupId>
       <artifactId>agrona</artifactId>
       <version>${version.agrona}</version>
     </dependency>
 
+    <!-- for TAR archives -->
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
       <version>${version.compress}</version>
+    </dependency>
+
+    <!-- for easy actuator clients -->
+    <dependency>
+      <groupId>io.github.openfeign</groupId>
+      <artifactId>feign-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.github.openfeign</groupId>
+      <artifactId>feign-jackson</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.github.openfeign</groupId>
+      <artifactId>feign-slf4j</artifactId>
+    </dependency>
+
+    <!-- required to deserialize the Clock's Instance interface -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <version>${version.jackson}</version>
     </dependency>
 
     <!-- mocking -->

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>camunda-release-parent</artifactId>
     <version>3.9.1</version>
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
-    <relativePath />
+    <relativePath/>
   </parent>
 
   <groupId>io.zeebe</groupId>
@@ -386,7 +386,7 @@
               <goal>check</goal>
             </goals>
             <phase>validate</phase>
-            <configuration />
+            <configuration/>
           </execution>
         </executions>
       </plugin>
@@ -456,7 +456,7 @@
             </goals>
             <configuration>
               <rules>
-                <banDuplicatePomDependencyVersions />
+                <banDuplicatePomDependencyVersions/>
               </rules>
             </configuration>
           </execution>

--- a/src/main/java/io/zeebe/containers/clock/ZeebeClock.java
+++ b/src/main/java/io/zeebe/containers/clock/ZeebeClock.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2021 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.containers.clock;
+
+import feign.Target.HardCodedTarget;
+import io.zeebe.containers.ZeebeNode;
+import java.net.URL;
+import java.time.Duration;
+import java.time.Instant;
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+/**
+ * A high level API to interact with a node's actor clock.
+ *
+ * <p>You can use this to more easily test time based processes, such as triggering a broker to take
+ * a snapshot, triggering a timeout on the gateway, or triggering a timer in a deployed process.
+ *
+ * <p>Be careful as changing the actor clock can trigger multiple things to occur at the same time.
+ * Even though you only want to trigger your BPMN process's timer event, changing the clock can
+ * trigger a Raft election as a side effect, causing temporary unavailability and introducing
+ * uncertainty in your tests. When using this, try to ensure that the scope of the test (both in
+ * terms of setup and assertions) is as narrow as possible.
+ *
+ * <p>NOTE: this is only compatible with Zeebe versions 1.3.x and above.
+ */
+@API(status = Status.EXPERIMENTAL)
+public interface ZeebeClock {
+
+  /**
+   * Pins the clock to the given instant, after which time will stop ticking. You can use {@link
+   * #addTime(Duration)} to rewind/advance time after this. Using either of these methods will not
+   * however "unfreeze" time. To do so, you need to call {@link #resetTime()}.
+   *
+   * @param time the time to pin the clock at
+   * @return the clock's current time after pinning (which should be the given {@code time})
+   * @throws ZeebeClockException if any error occur; inspect the cause to know more
+   */
+  Instant pinTime(final Instant time);
+
+  /**
+   * Adds the given offset to the current clock. To rewind time, pass a negative duration. If the
+   * clock is pinned, the offset is added to/subtracted from the pinned time, but time is remains
+   * frozen.
+   *
+   * @param offset the offset to add to/subtract from the clock's current time
+   * @return the clock's current time after adding the offset
+   * @throws ZeebeClockException if any error occur; inspect the cause to know more
+   */
+  Instant addTime(final Duration offset);
+
+  /**
+   * @return the clock's current time
+   * @throws ZeebeClockException if any error occur; inspect the cause to know more
+   */
+  Instant getCurrentTime();
+
+  /**
+   * Resets the time to the actual system time of the node. This will unpin and unfreeze time if the
+   * clock was previously pinned, and will also remove any offsets.
+   *
+   * @return the clock's current time after reset
+   * @throws ZeebeClockException if any error occur; inspect the cause to know more
+   */
+  Instant resetTime();
+
+  /**
+   * Factory method for the default clock implementation, targeting the given {@link ZeebeNode}.
+   *
+   * @param zeebe the Zeebe node to interact with
+   * @return a default implementation of the clock targeting the given node
+   */
+  static ZeebeClock newDefaultClock(final ZeebeNode<?> zeebe) {
+    return new ZeebeClockImpl(new ZeebeClockTarget(zeebe));
+  }
+
+  /**
+   * Factory method for the default clock implementation, targeting some arbitrary URL.
+   *
+   * @param url the actuator clock endpoint URL
+   * @return a default implementation of the clock targeting the given URL
+   */
+  static ZeebeClock newDefaultClock(final URL url) {
+    return new ZeebeClockImpl(new HardCodedTarget<>(ZeebeClockClient.class, url.toString()));
+  }
+
+  /**
+   * Every clock operation can throw this exception. Most of the time, it will simply act as a
+   * wrapper for more specific exceptions. However, it is useful to provide users a way to handle
+   * errors that occurred specifically when interacting with the clock as opposed to more generic
+   * exceptions. It also provides a unified way to handle errors with multiple implementations of
+   * the interface.
+   */
+  final class ZeebeClockException extends RuntimeException {
+    public ZeebeClockException(final Throwable cause) {
+      super(cause);
+    }
+  }
+}

--- a/src/main/java/io/zeebe/containers/clock/ZeebeClockClient.java
+++ b/src/main/java/io/zeebe/containers/clock/ZeebeClockClient.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2021 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.containers.clock;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonCreator.Mode;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import feign.Headers;
+import feign.Param;
+import feign.RequestLine;
+import java.time.Instant;
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+@API(status = Status.INTERNAL)
+interface ZeebeClockClient {
+  @RequestLine("GET /actuator/clock")
+  @Headers("Accept: application/json")
+  Response getCurrentTime();
+
+  @RequestLine("POST /actuator/clock/pin")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  Response pinTime(@Param("epochMilli") long epochMilli);
+
+  @RequestLine("POST /actuator/clock/add")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  Response addTime(@Param("offsetMilli") long offsetMilli);
+
+  @RequestLine("DELETE /actuator/clock")
+  @Headers("Accept: application/json")
+  Response resetTime();
+
+  final class Response {
+    @JsonProperty("epochMilli")
+    final long epochMilli;
+
+    @JsonProperty("instant")
+    final Instant instant;
+
+    @JsonCreator(mode = Mode.PROPERTIES)
+    Response(
+        final @JsonProperty("epochMilli") long epochMilli,
+        final @JsonProperty("instant") Instant instant) {
+      this.epochMilli = epochMilli;
+      this.instant = instant;
+    }
+  }
+}

--- a/src/main/java/io/zeebe/containers/clock/ZeebeClockImpl.java
+++ b/src/main/java/io/zeebe/containers/clock/ZeebeClockImpl.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2021 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.containers.clock;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import feign.Feign;
+import feign.Retryer;
+import feign.Target;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
+import feign.slf4j.Slf4jLogger;
+import io.zeebe.containers.clock.ZeebeClockClient.Response;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+@API(status = Status.INTERNAL)
+public final class ZeebeClockImpl implements ZeebeClock {
+  private static final Slf4jLogger LOGGER = new Slf4jLogger(ZeebeClockImpl.class);
+
+  private final ZeebeClockClient client;
+
+  ZeebeClockImpl(final Target<ZeebeClockClient> target) {
+    final List<Module> jacksonModules = Collections.singletonList(new JavaTimeModule());
+    client =
+        Feign.builder()
+            .encoder(new JacksonEncoder(jacksonModules))
+            .decoder(new JacksonDecoder(jacksonModules))
+            .logger(LOGGER)
+            .retryer(Retryer.NEVER_RETRY)
+            .target(target);
+  }
+
+  @Override
+  public Instant pinTime(final Instant time) {
+    final long epochMilli = time.toEpochMilli();
+    return performClientCall(c -> c.pinTime(epochMilli));
+  }
+
+  @Override
+  public Instant addTime(final Duration offset) {
+    final long offsetMilli = offset.toMillis();
+    return performClientCall(c -> c.addTime(offsetMilli));
+  }
+
+  @Override
+  public Instant getCurrentTime() {
+    return performClientCall(ZeebeClockClient::getCurrentTime);
+  }
+
+  @Override
+  public Instant resetTime() {
+    return performClientCall(ZeebeClockClient::resetTime);
+  }
+
+  private Instant performClientCall(final Function<ZeebeClockClient, Response> call) {
+    try {
+      final Response response = call.apply(client);
+      return response.instant;
+    } catch (final Exception e) {
+      throw new ZeebeClockException(e);
+    }
+  }
+}

--- a/src/main/java/io/zeebe/containers/clock/ZeebeClockTarget.java
+++ b/src/main/java/io/zeebe/containers/clock/ZeebeClockTarget.java
@@ -1,0 +1,41 @@
+package io.zeebe.containers.clock;
+
+import feign.Request;
+import feign.RequestTemplate;
+import feign.Target;
+import io.zeebe.containers.ZeebeNode;
+
+final class ZeebeClockTarget implements Target<ZeebeClockClient> {
+  private final ZeebeNode<?> zeebe;
+  private final String scheme;
+
+  ZeebeClockTarget(final ZeebeNode<?> zeebe) {
+    this(zeebe, "http");
+  }
+
+  ZeebeClockTarget(final ZeebeNode<?> zeebe, final String scheme) {
+    this.zeebe = zeebe;
+    this.scheme = scheme;
+  }
+
+  @Override
+  public Class<ZeebeClockClient> type() {
+    return ZeebeClockClient.class;
+  }
+
+  @Override
+  public String name() {
+    return String.format("%s clock", zeebe.getInternalHost());
+  }
+
+  @Override
+  public String url() {
+    return String.format("%s://%s", scheme, zeebe.getExternalMonitoringAddress());
+  }
+
+  @Override
+  public Request apply(final RequestTemplate input) {
+    input.target(url());
+    return input.request();
+  }
+}

--- a/src/main/java/io/zeebe/containers/clock/ZeebeClockTarget.java
+++ b/src/main/java/io/zeebe/containers/clock/ZeebeClockTarget.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2022 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.zeebe.containers.clock;
 
 import feign.Request;

--- a/src/test/java/io/zeebe/containers/clock/ZeebeClockTest.java
+++ b/src/test/java/io/zeebe/containers/clock/ZeebeClockTest.java
@@ -1,0 +1,89 @@
+package io.zeebe.containers.clock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.zeebe.containers.ZeebeBrokerContainer;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Contract testing for any {@link ZeebeClock} implementations.
+ *
+ * <p>NOTE: if there is ever more than one implementation, please turn the tests into parameterized
+ * tests and run the suite for each implementation.
+ *
+ * <p>NOTE: tests are run sequentially to allow reuse of the same backend
+ */
+@Execution(ExecutionMode.SAME_THREAD)
+@Testcontainers
+final class ZeebeClockTest {
+  @Container
+  private static final ZeebeBrokerContainer BROKER =
+      new ZeebeBrokerContainer().withEnv("ZEEBE_CLOCK_CONTROLLED", "true");
+
+  private final ZeebeClock clock = ZeebeClock.newDefaultClock(BROKER);
+
+  @AfterEach
+  void afterEach() {
+    ZeebeClock.newDefaultClock(BROKER).resetTime();
+  }
+
+  @Test
+  void shouldGetCurrentTime() {
+    // given
+    final Instant pinnedTime = clock.pinTime(Instant.now());
+
+    // when
+    final Instant currentTime = clock.getCurrentTime();
+
+    // then
+    assertThat(currentTime).isEqualTo(pinnedTime);
+  }
+
+  @Test
+  void shouldPinTime() {
+    // given
+    final Instant previousTime = clock.getCurrentTime();
+    final Instant expectedPinnedTime = previousTime.plusSeconds(10);
+
+    // when
+    final Instant actualPinnedTime = clock.pinTime(expectedPinnedTime);
+
+    // then
+    assertThat(actualPinnedTime).isAfter(previousTime).isEqualTo(expectedPinnedTime);
+  }
+
+  @Test
+  void shouldAddTime() {
+    // given
+    final Instant pinnedTime = clock.pinTime(Instant.now());
+    final Duration offset = Duration.ofDays(1);
+
+    // when
+    final Instant modifiedTime = clock.addTime(offset);
+
+    // then
+    final Instant expectedTime = pinnedTime.plus(offset);
+    assertThat(modifiedTime).isEqualTo(pinnedTime.plus(offset)).isEqualTo(expectedTime);
+  }
+
+  @Test
+  void shouldResetTime() {
+    // given
+    final Instant pinnedTime = clock.pinTime(Instant.now());
+    final Duration offset = Duration.ofDays(1);
+
+    // when
+    final Instant modifiedTime = clock.addTime(offset);
+    final Instant resetTime = clock.resetTime();
+
+    // then
+    assertThat(resetTime).isBefore(modifiedTime).isAfter(pinnedTime);
+  }
+}

--- a/src/test/java/io/zeebe/containers/clock/ZeebeClockTest.java
+++ b/src/test/java/io/zeebe/containers/clock/ZeebeClockTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2022 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.zeebe.containers.clock;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/io/zeebe/containers/examples/clock/TriggerTimerCatchEventTest.java
+++ b/src/test/java/io/zeebe/containers/examples/clock/TriggerTimerCatchEventTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2022 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.zeebe.containers.examples.clock;
 
 import io.camunda.zeebe.client.ZeebeClient;
@@ -15,7 +30,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.testcontainers.junit.jupiter.Container;

--- a/src/test/java/io/zeebe/containers/examples/clock/TriggerTimerCatchEventTest.java
+++ b/src/test/java/io/zeebe/containers/examples/clock/TriggerTimerCatchEventTest.java
@@ -1,0 +1,90 @@
+package io.zeebe.containers.examples.clock;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.api.worker.JobHandler;
+import io.camunda.zeebe.client.api.worker.JobWorker;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.containers.ZeebeContainer;
+import io.zeebe.containers.clock.ZeebeClock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * This example showcases how to test triggering a timer catch event by modifying the broker's actor
+ * clock once the instance has been created. This is done by deploying a simple process which has a
+ * start event, followed by a timer catch event, then a service task, and finally an end event. The
+ * timer catch event is set to trigger one day from now. Additionally, a worker is set up from the
+ * start to poll for the task immediately following the catch event.
+ *
+ * <p>Once deployed, the broker's actor clock is advanced by one day, and we can verify that one job
+ * was activated by the worker - this means that the instance has passed the timer catch event.
+ */
+@Testcontainers
+final class TriggerTimerCatchEventTest {
+  private static final String JOB_TYPE = "type";
+  private static final Duration TIME_OFFSET = Duration.ofDays(1);
+  private static final Instant TIMER_DATE = Instant.now().plus(TIME_OFFSET);
+
+  @Container
+  private final ZeebeContainer zeebeContainer =
+      new ZeebeContainer().withEnv("ZEEBE_CLOCK_CONTROLLED", "true");
+
+  @Test
+  @Timeout(value = 5, unit = TimeUnit.MINUTES)
+  void shouldTriggerTimerStartEvent() {
+    // given
+    final ZeebeClock clock = ZeebeClock.newDefaultClock(zeebeContainer);
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .intermediateCatchEvent()
+            .timerWithDate(TIMER_DATE.toString())
+            .serviceTask("task", b -> b.zeebeJobType(JOB_TYPE))
+            .endEvent()
+            .done();
+    final List<ActivatedJob> activatedJobs = new CopyOnWriteArrayList<>();
+    final Instant brokerTime;
+
+    // when
+    final JobHandler handler = (client, job) -> activatedJobs.add(job);
+    try (final ZeebeClient client = newZeebeClient(zeebeContainer);
+        final JobWorker worker = newJobWorker(handler, client)) {
+      client.newDeployCommand().addProcessModel(process, "process.bpmn").send().join();
+      client.newCreateInstanceCommand().bpmnProcessId("process").latestVersion().send().join();
+      brokerTime = clock.addTime(TIME_OFFSET);
+      Awaitility.await("until a job has been activated by the worker")
+          .untilAsserted(() -> Assertions.assertThat(activatedJobs).hasSize(1));
+    }
+
+    // then
+    Assertions.assertThat(activatedJobs)
+        .as("the timer event was triggered and a job is now available")
+        .hasSize(1);
+    Assertions.assertThat(brokerTime)
+        .as("the modified time is at least equal to one day from now")
+        .isAfterOrEqualTo(TIMER_DATE);
+  }
+
+  private JobWorker newJobWorker(final JobHandler handler, final ZeebeClient client) {
+    return client.newWorker().jobType(JOB_TYPE).handler(handler).open();
+  }
+
+  private ZeebeClient newZeebeClient(final ZeebeContainer node) {
+    return ZeebeClient.newClientBuilder()
+        .gatewayAddress(node.getExternalGatewayAddress())
+        .usePlaintext()
+        .build();
+  }
+}

--- a/src/test/java/io/zeebe/containers/examples/clock/TriggerTimerStartEventTest.java
+++ b/src/test/java/io/zeebe/containers/examples/clock/TriggerTimerStartEventTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2022 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.zeebe.containers.examples.clock;
 
 import io.camunda.zeebe.client.ZeebeClient;
@@ -15,7 +30,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.testcontainers.junit.jupiter.Container;

--- a/src/test/java/io/zeebe/containers/examples/clock/TriggerTimerStartEventTest.java
+++ b/src/test/java/io/zeebe/containers/examples/clock/TriggerTimerStartEventTest.java
@@ -1,0 +1,88 @@
+package io.zeebe.containers.examples.clock;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.api.worker.JobHandler;
+import io.camunda.zeebe.client.api.worker.JobWorker;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.zeebe.containers.ZeebeContainer;
+import io.zeebe.containers.clock.ZeebeClock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * This example showcases how to test triggering a timer start event by modifying the broker's actor
+ * clock after the process has been deployed. This is done by deploying a simple process which has a
+ * timer start event, then a service task, followed by an end event. The timer start event is set to
+ * trigger one day from now. Additionally, a worker is set up from the start to poll for the tasks
+ * from instances of the deployed process.
+ *
+ * <p>Once deployed, the broker's actor clock is advanced by one day, and we can verify that one job
+ * was activated by the worker - this means that one instance of the process was correctly created.
+ */
+@Testcontainers
+final class TriggerTimerStartEventTest {
+  private static final String JOB_TYPE = "type";
+  private static final Duration TIME_OFFSET = Duration.ofDays(1);
+  private static final Instant TIMER_DATE = Instant.now().plus(TIME_OFFSET);
+
+  @Container
+  private final ZeebeContainer zeebeContainer =
+      new ZeebeContainer().withEnv("ZEEBE_CLOCK_CONTROLLED", "true");
+
+  @Test
+  @Timeout(value = 5, unit = TimeUnit.MINUTES)
+  void shouldTriggerTimerStartEvent() {
+    // given
+    final ZeebeClock clock = ZeebeClock.newDefaultClock(zeebeContainer);
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .timerWithDate(TIMER_DATE.toString())
+            .serviceTask("task", b -> b.zeebeJobType(JOB_TYPE))
+            .endEvent()
+            .done();
+    final List<ActivatedJob> activatedJobs = new CopyOnWriteArrayList<>();
+    final Instant brokerTime;
+
+    // when
+    final JobHandler handler = (client, job) -> activatedJobs.add(job);
+    try (final ZeebeClient client = newZeebeClient(zeebeContainer);
+        final JobWorker worker = newJobWorker(handler, client)) {
+      client.newDeployCommand().addProcessModel(process, "process.bpmn").send().join();
+      brokerTime = clock.addTime(TIME_OFFSET);
+      Awaitility.await("until a job has been activated by the worker")
+          .untilAsserted(() -> Assertions.assertThat(activatedJobs).hasSize(1));
+    }
+
+    // then
+    Assertions.assertThat(activatedJobs)
+        .as("the timer event was triggered and a job is now available")
+        .hasSize(1);
+    Assertions.assertThat(brokerTime)
+        .as("the modified time is at least equal to one day from now")
+        .isAfterOrEqualTo(TIMER_DATE);
+  }
+
+  private JobWorker newJobWorker(final JobHandler handler, final ZeebeClient client) {
+    return client.newWorker().jobType(JOB_TYPE).handler(handler).open();
+  }
+
+  private ZeebeClient newZeebeClient(final ZeebeContainer node) {
+    return ZeebeClient.newClientBuilder()
+        .gatewayAddress(node.getExternalGatewayAddress())
+        .usePlaintext()
+        .build();
+  }
+}

--- a/src/test/resources/simplelogger.properties
+++ b/src/test/resources/simplelogger.properties
@@ -1,3 +1,4 @@
+org.slf4j.simpleLogger.logFile=System.out
 org.slf4j.simplerLogger.showShortLogName=true
 org.slf4j.simpleLogger.defaultLogLevel=info
 org.slf4j.simpleLogger.log.io.zeebe.containers=debug


### PR DESCRIPTION
## Description

This PR adds a high level time traveling API, allowing users to easily read and optionally modify a node's actor clock. The default implementation is an `OpenFeign` based client with minimal dependencies which targets the node's actuator clock endpoint. Note that this only works with Zeebe versions 1.3 and above.

## Related issues

closes #223 

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
- [ ] Ensure all PR checks are green
