### PR TITLE
Downgrade project to use Java 8 for the build pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 17
+      - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          java-version: '17'
+          java-version: '8'
           distribution: 'temurin'
           cache: 'maven'
       - name: Build

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,9 +1,0 @@
---add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
---add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
---add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
---add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
---add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
---add-opens=java.base/java.util=ALL-UNNAMED
---add-opens=java.base/java.lang.reflect=ALL-UNNAMED
---add-opens=java.base/java.text=ALL-UNNAMED
---add-opens=java.desktop/java.awt.font=ALL-UNNAMED

--- a/README.md
+++ b/README.md
@@ -953,10 +953,9 @@ you will need to sign the [Contributor License Agreement](https://cla-assistant.
 In order to build from source, you will need to install maven 3.6+. You can find more about it on
 the [maven homepage](https://maven.apache.org/users/index.html).
 
-While the project targets Java 8 for compatibility purposes, for development you will need at least
-Java 11 - ideally Java 17, as that's what we use for continuous integration. We recommend installing
-any flavour of OpenJDK such
-as [Eclipse Temurin](https://projects.eclipse.org/projects/adoptium.temurin).
+The project targets Java 8 for compatibility purposes, and runs its build pipeline on Eclipse
+Temurin's Java 8 distribution. It will most likely work locally with other JDKs, but in case you
+run into build errors, you can try that distribution.
 
 Finally, you will need to [install Docker](https://docs.docker.com/get-docker/) on your local
 machine.

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
     <plugin.version.checkstyle>3.1.2</plugin.version.checkstyle>
     <plugin.version.dependency>3.2.0</plugin.version.dependency>
     <plugin.version.enforcer>3.0.0</plugin.version.enforcer>
+    <plugin.version.google-format>1.7</plugin.version.google-format>
     <plugin.version.gpg>3.0.1</plugin.version.gpg>
     <plugin.version.jar>3.2.2</plugin.version.jar>
     <plugin.version.javadoc>3.3.1</plugin.version.javadoc>
@@ -245,12 +246,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-test-util</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <version>${version.awaitility}</version>
@@ -324,9 +319,8 @@
         <configuration>
           <java>
             <googleJavaFormat>
-              <version>1.11.0</version>
+              <version>${plugin.version.google-format}</version>
               <style>GOOGLE</style>
-              <reflowLongStrings>true</reflowLongStrings>
             </googleJavaFormat>
             <licenseHeader>
               <file>${project.basedir}/HEADER</file>
@@ -455,8 +449,17 @@
               <goal>enforce</goal>
             </goals>
             <configuration>
+              <!-- see more https://maven.apache.org/enforcer/enforcer-rules/index.html -->
               <rules>
                 <banDuplicatePomDependencyVersions/>
+                <requireJavaVersion>
+                  <version>[1.8,)</version>
+                </requireJavaVersion>
+                <requireMavenVersion>
+                  <version>[3.6,)</version>
+                </requireMavenVersion>
+                <requireReleaseDeps/>
+                <requireUpperBoundDeps/>
               </rules>
             </configuration>
           </execution>

--- a/src/test/java/io/zeebe/containers/ZeebeBrokerNodeTest.java
+++ b/src/test/java/io/zeebe/containers/ZeebeBrokerNodeTest.java
@@ -23,8 +23,8 @@ import io.camunda.zeebe.client.api.response.DeploymentEvent;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
-import io.camunda.zeebe.test.util.asserts.TopologyAssert;
 import io.zeebe.containers.util.TestUtils;
+import io.zeebe.containers.util.TopologyAssert;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -166,7 +166,7 @@ class ZeebeBrokerNodeTest {
         .untilAsserted(
             () ->
                 TopologyAssert.assertThat(client.newTopologyRequest().send().join())
-                    .isComplete(1, 1));
+                    .isComplete(1, 1, 1));
   }
 
   private static Stream<Arguments> reuseDataTestCases() {

--- a/src/test/java/io/zeebe/containers/cluster/ZeebeClusterTest.java
+++ b/src/test/java/io/zeebe/containers/cluster/ZeebeClusterTest.java
@@ -19,8 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.Topology;
-import io.camunda.zeebe.test.util.asserts.TopologyAssert;
 import io.zeebe.containers.ZeebeGatewayNode;
+import io.zeebe.containers.util.TopologyAssert;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -59,7 +59,7 @@ final class ZeebeClusterTest {
     TopologyAssert.assertThat(topology)
         .as("the topology is complete for a one broker, one partition cluster")
         .hasBrokersCount(1)
-        .isComplete(1, 1);
+        .isComplete(1, 1, 1);
   }
 
   @Test
@@ -93,7 +93,7 @@ final class ZeebeClusterTest {
         TopologyAssert.assertThat(topology)
             .as("the topology is complete with 2 partitions and 2 brokers")
             .hasBrokersCount(2)
-            .isComplete(2, 2);
+            .isComplete(2, 2, 2);
       }
     }
   }
@@ -125,7 +125,7 @@ final class ZeebeClusterTest {
       TopologyAssert.assertThat(topology)
           .as("the topology is complete for a one broker, one partition cluster")
           .hasBrokersCount(1)
-          .isComplete(1, 1);
+          .isComplete(1, 1, 1);
     }
   }
 
@@ -160,8 +160,8 @@ final class ZeebeClusterTest {
             .isEqualTo(1);
         TopologyAssert.assertThat(topology)
             .as("the topology is complete for a one broker, one partition cluster")
-            .hasBrokersCount(1)
-            .isComplete(1, 1);
+            .isComplete(1, 1, 1)
+            .hasBrokersCount(1);
       }
     }
   }

--- a/src/test/java/io/zeebe/containers/util/TopologyAssert.java
+++ b/src/test/java/io/zeebe/containers/util/TopologyAssert.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright © 2022 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.zeebe.containers.util;
+
+import io.camunda.zeebe.client.api.response.BrokerInfo;
+import io.camunda.zeebe.client.api.response.PartitionInfo;
+import io.camunda.zeebe.client.api.response.Topology;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import org.assertj.core.api.AbstractObjectAssert;
+
+/** Convenience class to assert certain properties of a Zeebe cluster {@link Topology}. */
+@SuppressWarnings("UnusedReturnValue")
+public final class TopologyAssert extends AbstractObjectAssert<TopologyAssert, Topology> {
+
+  /** @param topology the actual topology to assert against */
+  public TopologyAssert(final Topology topology) {
+    super(topology, TopologyAssert.class);
+  }
+
+  /**
+   * A convenience factory method that's consistent with AssertJ conventions.
+   *
+   * @param actual the actual topology to assert against
+   * @return an instance of {@link TopologyAssert} to assert properties of the given topology
+   */
+  public static TopologyAssert assertThat(final Topology actual) {
+    return new TopologyAssert(actual);
+  }
+
+  /**
+   * Asserts that the actual topology is complete. A complete topology is one which has the expected
+   * number of brokers, the expected number of partitions, the expected number of replicas per
+   * partition, and one leader per partition.
+   *
+   * <p>This is a convenience method that combines all other assertions from this class.
+   *
+   * @param clusterSize the expected number of brokers in the cluster
+   * @param partitionCount the expected number of partitions in the cluster
+   * @param replicationFactor the expected number of replicas per partition
+   * @return itself for chaining
+   */
+  public TopologyAssert isComplete(
+      final int clusterSize, final int partitionCount, final int replicationFactor) {
+    isNotNull()
+        .hasBrokersCount(clusterSize)
+        .hasExpectedReplicasCount(partitionCount, replicationFactor)
+        .hasLeaderForEachPartition(partitionCount);
+
+    return myself;
+  }
+
+  /**
+   * Asserts that the topology reports the correct cluster size. Does not check whether the number
+   * of brokers is as expected, only the topology metadata.
+   *
+   * @param clusterSize the expected cluster size
+   * @return itself for chaining
+   */
+  public TopologyAssert hasClusterSize(final int clusterSize) {
+    isNotNull();
+
+    if (actual.getClusterSize() != clusterSize) {
+      throw failure("Expected cluster size to be <%d> but was <%d>", clusterSize, clusterSize);
+    }
+
+    return myself;
+  }
+
+  /**
+   * Asserts that the topology reports the right number of partitions. Does not verify that each
+   * partition is present via the brokers list, only check the topology metadata.
+   *
+   * @param partitionsCount the expected partitions count
+   * @return itself for chaining
+   */
+  public TopologyAssert hasPartitionsCount(final int partitionsCount) {
+    isNotNull();
+
+    if (actual.getPartitionsCount() != partitionsCount) {
+      throw failure(
+          "Expected partitions count to be <%d> but was <%d>",
+          partitionsCount, actual.getPartitionsCount());
+    }
+
+    return myself;
+  }
+
+  /**
+   * Asserts that the topology reports the expected replication factor. Does not actually check that
+   * each reported partition contains the expected number of replicas, but simply the topology's
+   * metadata.
+   *
+   * @param replicationFactor the expected replication factor
+   * @return itself for chaining
+   */
+  public TopologyAssert hasReplicationFactor(final int replicationFactor) {
+    isNotNull();
+
+    if (actual.getReplicationFactor() != replicationFactor) {
+      throw failure(
+          "Expected replication factor to be <%d> but was <%d>",
+          replicationFactor, actual.getReplicationFactor());
+    }
+
+    return myself;
+  }
+
+  /**
+   * Asserts that the brokers list contains the expected number of brokers.
+   *
+   * @param count the expected brokers count
+   * @return itself for chaining
+   */
+  public TopologyAssert hasBrokersCount(final int count) {
+    isNotNull().hasClusterSize(count);
+
+    if (actual.getBrokers().size() != count) {
+      throw failure(
+          "Expected topology to contain <%d> brokers, but it contains <%s>",
+          count, actual.getBrokers());
+    }
+
+    return myself;
+  }
+
+  /**
+   * Asserts that each partition has the expected number of replicas.
+   *
+   * <p>NOTE: this will not work with the fixed partitioning scheme.
+   *
+   * @param partitionsCount the partition count in the cluster
+   * @param replicationFactor the replication factor
+   * @return itself for chaining
+   */
+  public TopologyAssert hasExpectedReplicasCount(
+      final int partitionsCount, final int replicationFactor) {
+    isNotNull().hasPartitionsCount(partitionsCount).hasReplicationFactor(replicationFactor);
+
+    final Map<Integer, List<PartitionBroker>> partitionMap = buildPartitionsMap();
+
+    if (partitionMap.size() != partitionsCount) {
+      throw failure(
+          "Expected <%d> partitions to have <%d> replicas, but there are <%d> partitions in the topology: partitions <%s>",
+          partitionsCount, replicationFactor, partitionMap.size(), partitionMap.keySet());
+    }
+
+    for (final Entry<Integer, List<PartitionBroker>> partitionBrokers : partitionMap.entrySet()) {
+      final int partitionId = partitionBrokers.getKey();
+      final List<PartitionBroker> brokers = partitionBrokers.getValue();
+
+      if (brokers.size() != replicationFactor) {
+        throw failure(
+            "Expected partition <%d> to have <%d> replicas, but it has <%d>: brokers <%s>",
+            partitionId, replicationFactor, brokers);
+      }
+    }
+
+    return myself;
+  }
+
+  /**
+   * Asserts that each partition has exactly one leader.
+   *
+   * @param partitionsCount the expected number of partitions
+   * @return itself for chaining
+   */
+  public TopologyAssert hasLeaderForEachPartition(final int partitionsCount) {
+    isNotNull().hasPartitionsCount(partitionsCount);
+
+    final Map<Integer, List<PartitionBroker>> partitionMap = buildPartitionsMap();
+
+    if (partitionMap.size() != partitionsCount) {
+      throw failure(
+          "Expected <%d> partitions to have one leader, but there are <%d> partitions in the topology: partitions <%s>",
+          partitionsCount, partitionMap.size(), partitionMap.keySet());
+    }
+
+    for (final Entry<Integer, List<PartitionBroker>> partitionBrokers : partitionMap.entrySet()) {
+      final int partitionId = partitionBrokers.getKey();
+      final List<PartitionBroker> brokers = partitionBrokers.getValue();
+      final List<PartitionBroker> leaders =
+          partitionBrokers.getValue().stream()
+              .filter(p -> p.partitionInfo.isLeader())
+              .collect(Collectors.toList());
+
+      if (leaders.isEmpty()) {
+        throw failure(
+            "Expected partition <%d> to have a leader, but it only has the following brokers: <%s>",
+            partitionId, brokers);
+      }
+
+      if (leaders.size() > 1) {
+        throw failure(
+            "Expected partition <%d> to have a leader, but it has the following leaders: <%s>",
+            partitionId, leaders);
+      }
+    }
+
+    return myself;
+  }
+
+  private Map<Integer, List<PartitionBroker>> buildPartitionsMap() {
+    final Map<Integer, List<PartitionBroker>> partitionMap = new HashMap<>();
+
+    for (final BrokerInfo broker : actual.getBrokers()) {
+      for (final PartitionInfo partition : broker.getPartitions()) {
+        final List<PartitionBroker> partitionBrokers =
+            partitionMap.computeIfAbsent(partition.getPartitionId(), ignored -> new ArrayList<>());
+        partitionBrokers.add(new PartitionBroker(partition, broker));
+      }
+    }
+
+    return partitionMap;
+  }
+
+  private static final class PartitionBroker {
+    private final PartitionInfo partitionInfo;
+    private final BrokerInfo brokerInfo;
+
+    private PartitionBroker(final PartitionInfo partitionInfo, final BrokerInfo brokerInfo) {
+      this.partitionInfo = partitionInfo;
+      this.brokerInfo = brokerInfo;
+    }
+
+    @Override
+    public String toString() {
+      return "PartitionBroker{"
+          + "partitionId="
+          + partitionInfo.getPartitionId()
+          + ", broker="
+          + brokerInfo
+          + '}';
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR downgrades the project's build pipeline to Java 8. Since we target Java 8, to ensure that users on Java 8 can use this library, we need to also run our complete pipeline over Java 8. Unfortunately targeting the language level is not enough as that only guarantees newer language features are not used, but does not guarantee things such as using new standard library functions which are not available in Java 8.

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
- [ ] Ensure all PR checks are green
