### PR TITLE
Showcase startable cluster via docs and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,14 +415,18 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
  * Showcases how you can create a test with a cluster of two brokers and one standalone gateway.
  * Configuration is kept to minimum, as the goal here is only to showcase how to connect the
  * different nodes together.
  */
+@Testcontainers
 class ZeebeClusterWithGatewayExampleTest {
 
+  @Container
   private final ZeebeCluster cluster =
     ZeebeCluster.builder()
       .withEmbeddedGateway(false)
@@ -432,19 +436,13 @@ class ZeebeClusterWithGatewayExampleTest {
       .withReplicationFactor(1)
       .build();
 
-  @AfterEach
-  void tearDown() {
-    cluster.stop();
-  }
-
   @Test
   @Timeout(value = 15, unit = TimeUnit.MINUTES)
   void shouldStartCluster() {
     // given
-    cluster.start();
+    final Topology topology;
 
     // when
-    final Topology topology;
     try (final ZeebeClient client = cluster.newClientBuilder().build()) {
       topology = client.newTopologyRequest().send().join(5, TimeUnit.SECONDS);
     }
@@ -475,39 +473,33 @@ startup time:
 package com.acme.zeebe;
 
 import io.zeebe.containers.cluster.ZeebeCluster;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
+@Testcontainers
 class ZeebeHugeClusterTest {
 
+  @Container
   private final ZeebeCluster cluster =
-    ZeebeCluster.builder()
-      .withEmbeddedGateway(false)
-      .withGatewaysCount(3)
-      .withBrokersCount(6)
-      .withPartitionsCount(6)
-      .withReplicationFactor(3)
-      .build();
-
-  @AfterEach
-  void tearDown() {
-    cluster.stop();
-  }
+      ZeebeCluster.builder()
+          .withEmbeddedGateway(false)
+          .withGatewaysCount(3)
+          .withBrokersCount(6)
+          .withPartitionsCount(6)
+          .withReplicationFactor(3)
+          // configure each container to have a high start up time as they get started in parallel
+          .withNodeConfig(node -> node.self().withStartupTimeout(Duration.ofMinutes(5)))
+          .build();
 
   @Test
   @Timeout(value = 30, unit = TimeUnit.MINUTES)
   void shouldStartCluster() {
-    // given
-    // configure each container to have a high start up time as they get started in parallel
-    cluster.getBrokers().values()
-      .forEach(broker -> broker.self().withStartupTimeout(Duration.ofMinutes(5)));
-    cluster.getGateways().values()
-      .forEach(gateway -> gateway.self().withStartupTimeout(Duration.ofMinutes(5)));
-    cluster.start();
-
-    // test more things
+    // test things
   }
 }
 ```

--- a/src/test/java/io/zeebe/containers/examples/cluster/ZeebeClusterSingleNodeExampleTest.java
+++ b/src/test/java/io/zeebe/containers/examples/cluster/ZeebeClusterSingleNodeExampleTest.java
@@ -24,12 +24,16 @@ import java.util.concurrent.TimeUnit;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
  * This example show cases how to create a simple test against a single node broker with embedded
  * gateway.
  */
+@Testcontainers
 class ZeebeClusterSingleNodeExampleTest {
+  @Container
   private final ZeebeCluster cluster =
       ZeebeCluster.builder()
           .withGatewaysCount(0)
@@ -43,10 +47,9 @@ class ZeebeClusterSingleNodeExampleTest {
   @Timeout(value = 5, unit = TimeUnit.MINUTES)
   void shouldConnectToZeebe() {
     // given
-    cluster.start();
+    final Topology topology;
 
     // when
-    final Topology topology;
     try (final ZeebeClient client = cluster.newClientBuilder().build()) {
       topology = client.newTopologyRequest().send().join(5, TimeUnit.SECONDS);
     }

--- a/src/test/java/io/zeebe/containers/examples/cluster/ZeebeClusterWithEmbeddedGatewaysExampleTest.java
+++ b/src/test/java/io/zeebe/containers/examples/cluster/ZeebeClusterWithEmbeddedGatewaysExampleTest.java
@@ -22,7 +22,6 @@ import io.zeebe.containers.cluster.ZeebeCluster;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.testcontainers.junit.jupiter.Container;

--- a/src/test/java/io/zeebe/containers/examples/cluster/ZeebeClusterWithEmbeddedGatewaysExampleTest.java
+++ b/src/test/java/io/zeebe/containers/examples/cluster/ZeebeClusterWithEmbeddedGatewaysExampleTest.java
@@ -25,12 +25,16 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
  * This showcases how to start a cluster of brokers with embedded gateways, removing the need for a
  * standalone gateway container.
  */
+@Testcontainers
 class ZeebeClusterWithEmbeddedGatewaysExampleTest {
+  @Container
   private final ZeebeCluster cluster =
       ZeebeCluster.builder()
           .withGatewaysCount(0)
@@ -40,19 +44,13 @@ class ZeebeClusterWithEmbeddedGatewaysExampleTest {
           .withEmbeddedGateway(true)
           .build();
 
-  @AfterEach
-  void tearDown() {
-    cluster.stop();
-  }
-
   @Test
   @Timeout(value = 15, unit = TimeUnit.MINUTES)
   void shouldStartCluster() {
     // given
-    cluster.start();
+    final Topology topology;
 
     // when
-    final Topology topology;
     try (final ZeebeClient client = cluster.newClientBuilder().build()) {
       topology = client.newTopologyRequest().send().join(5, TimeUnit.SECONDS);
     }

--- a/src/test/java/io/zeebe/containers/examples/cluster/ZeebeClusterWithGatewayExampleTest.java
+++ b/src/test/java/io/zeebe/containers/examples/cluster/ZeebeClusterWithGatewayExampleTest.java
@@ -22,7 +22,6 @@ import io.zeebe.containers.cluster.ZeebeCluster;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.testcontainers.junit.jupiter.Container;

--- a/src/test/java/io/zeebe/containers/examples/cluster/ZeebeClusterWithGatewayExampleTest.java
+++ b/src/test/java/io/zeebe/containers/examples/cluster/ZeebeClusterWithGatewayExampleTest.java
@@ -25,13 +25,17 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
  * Showcases how you can create a test with a cluster of two brokers and one standalone gateway.
  * Configuration is kept to minimum, as the goal here is only to showcase how to connect the
  * different nodes together.
  */
+@Testcontainers
 class ZeebeClusterWithGatewayExampleTest {
+  @Container
   private final ZeebeCluster cluster =
       ZeebeCluster.builder()
           .withEmbeddedGateway(false)
@@ -41,19 +45,13 @@ class ZeebeClusterWithGatewayExampleTest {
           .withReplicationFactor(1)
           .build();
 
-  @AfterEach
-  void tearDown() {
-    cluster.stop();
-  }
-
   @Test
   @Timeout(value = 15, unit = TimeUnit.MINUTES)
   void shouldStartCluster() {
     // given
-    cluster.start();
+    final Topology topology;
 
     // when
-    final Topology topology;
     try (final ZeebeClient client = cluster.newClientBuilder().build()) {
       topology = client.newTopologyRequest().send().join(5, TimeUnit.SECONDS);
     }


### PR DESCRIPTION
## Description

This PR updates the README and the examples to showcase that a `ZeebeCluster`, which implements `Startable`, can be managed by the `Testcontainers` Junit 5 extension. Simply annotate your test with `@Testcontainers`, your cluster with `@Container`, and you're good to go.

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/camunda-cloud/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/camunda-cloud/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
- [ ] Ensure all PR checks are green
