### PR TITLE
Flatten deployed POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
 
     <!-- maven extensions -->
     <extension.version.os-maven-plugin>1.6.1</extension.version.os-maven-plugin>
+    <plugin.version.flatten>1.2.2</plugin.version.flatten>
   </properties>
 
   <dependencyManagement>
@@ -462,6 +463,36 @@
                 <requireUpperBoundDeps/>
               </rules>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!--
+        generate a simplified POM; this is very useful for projects consuming
+        zeebe-test-container, as it will simplify dependency convergence for these projects
+      -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <version>${plugin.version.flatten}</version>
+        <configuration>
+          <flattenMode>ossrh</flattenMode>
+          <outputDirectory>${project.build.directory}</outputDirectory>
+        </configuration>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <phase>process-resources</phase>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+            <phase>clean</phase>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
## Description

Adds flatten-maven-plugin to the build pipeline. This will generate a flattened POM, which removes any POM hierarchy, substitutes all properties, removes non compile dependencies, and more. This solves issues when it comes to dependency management for consumers of this project by greatly reducing how much they have to care when it comes to dependency convergence.

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/camunda-cloud/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/camunda-cloud/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
- [ ] Ensure all PR checks are green
