### PR TITLE
Bump Zeebe dependency to 8.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,23 +49,23 @@
     <spotless.check.skip>${skipChecks}</spotless.check.skip>
 
     <!-- project dependencies -->
-    <version.agrona>1.14.0</version.agrona>
+    <version.agrona>1.15.0</version.agrona>
     <version.apiguardian>1.1.2</version.apiguardian>
     <version.assertj>3.22.0</version.assertj>
-    <version.awaitility>4.1.1</version.awaitility>
+    <version.awaitility>4.2.0</version.awaitility>
     <version.checkstyle>9.3</version.checkstyle>
     <version.compress>1.21</version.compress>
     <version.docker-java>3.2.12</version.docker-java>
     <version.duct-tape>1.0.8</version.duct-tape>
     <version.feign>11.8</version.feign>
-    <version.jackson>2.13.1</version.jackson>
+    <version.jackson>2.13.2</version.jackson>
     <version.junit-jupiter>5.8.2</version.junit-jupiter>
     <version.junit-surefire-provider>1.3.2</version.junit-surefire-provider>
-    <version.mockito>4.3.1</version.mockito>
+    <version.mockito>4.4.0</version.mockito>
     <version.revapi>0.26.1</version.revapi>
     <version.slf4j>1.7.36</version.slf4j>
     <version.testcontainers>1.16.3</version.testcontainers>
-    <version.zeebe>1.3.3</version.zeebe>
+    <version.zeebe>8.0.0</version.zeebe>
 
     <!-- plugin version -->
     <plugin.version.checkstyle>3.1.2</plugin.version.checkstyle>
@@ -117,6 +117,13 @@
         <version>${version.feign}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+
+      <!-- dependencies entirely for convergence -->
+      <dependency>
+        <groupId>com.google.errorprone</groupId>
+        <artifactId>error_prone_annotations</artifactId>
+        <version>2.13.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
## Description

This PR updates the base Zeebe dependency to 8.0.0. It will require a new release, but if everything works, then just a minor release should be fine.

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/camunda-cloud/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/camunda-cloud/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
- [ ] Ensure all PR checks are green

