### PR TITLE
feat(engine): allow setting the exporter receiver port

### DIFF
--- a/engine/src/main/java/io/zeebe/containers/engine/ContainerEngine.java
+++ b/engine/src/main/java/io/zeebe/containers/engine/ContainerEngine.java
@@ -165,6 +165,15 @@ public interface ContainerEngine extends Startable, ZeebeTestEngine {
     Builder withAutoAcknowledge(final boolean acknowledge);
 
     /**
+     * Pre-assigns the port to use for the debug receive, i.e. the socket used to receive exported
+     * records from the container(s). By default, this is 0, i.e. a random port.
+     *
+     * @param port the port to assign to the receiver
+     * @return itself for chaining
+     */
+    Builder withDebugReceiverPort(final int port);
+
+    /**
      * Builds a {@link ContainerEngine} based on the configuration. If nothing else was called, will
      * build an engine using a default {@link io.zeebe.containers.ZeebeContainer}, an idle period of
      * 1 second, and a grace period of 0.

--- a/engine/src/main/java/io/zeebe/containers/engine/ContainerEngineBuilder.java
+++ b/engine/src/main/java/io/zeebe/containers/engine/ContainerEngineBuilder.java
@@ -42,6 +42,7 @@ final class ContainerEngineBuilder implements Builder {
   private Duration idlePeriod;
   private Duration gracePeriod;
   private boolean autoAcknowledge;
+  private int debugReceiverPort;
 
   @Override
   public <T extends GenericContainer<T> & ZeebeGatewayNode<T> & ZeebeBrokerNode<T>>
@@ -99,7 +100,13 @@ final class ContainerEngineBuilder implements Builder {
     return this;
   }
 
-  @SuppressWarnings("unchecked")
+  @Override
+  public Builder withDebugReceiverPort(final int debugReceiverPort) {
+    this.debugReceiverPort = debugReceiverPort;
+    return this;
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
   @Override
   public ContainerEngine build() {
     final Duration listGracePeriod = Optional.ofNullable(gracePeriod).orElse(DEFAULT_GRACE_PERIOD);
@@ -107,7 +114,9 @@ final class ContainerEngineBuilder implements Builder {
     final InfiniteList<Record<?>> records = new InfiniteList<>(listGracePeriod);
     final DebugReceiverStream recordStream =
         new DebugReceiverStream(
-            records, new DebugReceiver(records::add, autoAcknowledge), receiveIdlePeriod);
+            records,
+            new DebugReceiver(records::add, debugReceiverPort, autoAcknowledge),
+            receiveIdlePeriod);
 
     try {
       if (container != null) {


### PR DESCRIPTION
## Description

This PR allows setting an explicit debug receiver port when building your container engine.

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/camunda-cloud/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/camunda-cloud/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
- [ ] Ensure all PR checks are green

