### PR TITLE
Allow configuring the debug receiver in general

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,13 @@ on:
       - '.github/workflows/test.yml'
       - '.github/workflows/lint.yml'
   workflow_dispatch: { }
+
+concurrency:
+  # add a sub-key using the run ID whenever this is called via workflow dispatch (i.e. manually by a user); in that
+  # case, we do want to have as many runs as a user wants. for all other cases, this will only run once.
+  group: ${{ github.workflow }}-${{ (github.event_name == 'workflow_dispatch' && github.run_id) || '' }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Linting & Analysis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: Continuous Integration
 on:
   pull_request:
+    branches: [ main ]
     paths:
       - '**/*.java'
       - '**/pom.xml'

--- a/engine/src/main/java/io/zeebe/containers/engine/ContainerEngine.java
+++ b/engine/src/main/java/io/zeebe/containers/engine/ContainerEngine.java
@@ -21,12 +21,11 @@ import io.zeebe.containers.ZeebeBrokerNode;
 import io.zeebe.containers.ZeebeGatewayNode;
 import io.zeebe.containers.cluster.ZeebeCluster;
 import io.zeebe.containers.exporter.DebugReceiver;
+import java.time.Duration;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.lifecycle.Startable;
-
-import java.time.Duration;
 
 /**
  * A {@link ContainerEngine} is a {@link ZeebeTestEngine} implementation which wraps a container or

--- a/engine/src/main/java/io/zeebe/containers/engine/ContainerEngine.java
+++ b/engine/src/main/java/io/zeebe/containers/engine/ContainerEngine.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.process.test.assertions.ProcessInstanceAssert;
 import io.zeebe.containers.ZeebeBrokerNode;
 import io.zeebe.containers.ZeebeGatewayNode;
 import io.zeebe.containers.cluster.ZeebeCluster;
+import io.zeebe.containers.exporter.DebugReceiver;
 import java.time.Duration;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -35,19 +36,6 @@ import org.testcontainers.lifecycle.Startable;
  */
 @API(status = Status.EXPERIMENTAL)
 public interface ContainerEngine extends Startable, ZeebeTestEngine {
-
-  /**
-   * Marks all records with a position less than {@code position} on partition with ID {@code
-   * partitionId} as acknowledged, meaning they can now be deleted from Zeebe.
-   *
-   * <p>Note that this is not a synchronous operation, but instead will take effect when the next
-   * record is exported. See {@link io.zeebe.containers.exporter.DebugReceiver#acknowledge(int,
-   * long)} for more.
-   *
-   * @param partitionId the ID of the partition on which to acknowledge
-   * @param position the position up to which they should be acknowledged
-   */
-  void acknowledge(final int partitionId, final long position);
 
   /**
    * Returns a default builder. Calling {@link Builder#build()} on a fresh builder will return a
@@ -69,6 +57,19 @@ public interface ContainerEngine extends Startable, ZeebeTestEngine {
   static ContainerEngine createDefault() {
     return builder().build();
   }
+
+  /**
+   * Marks all records with a position less than {@code position} on partition with ID {@code
+   * partitionId} as acknowledged, meaning they can now be deleted from Zeebe.
+   *
+   * <p>Note that this is not a synchronous operation, but instead will take effect when the next
+   * record is exported. See {@link io.zeebe.containers.exporter.DebugReceiver#acknowledge(int,
+   * long)} for more.
+   *
+   * @param partitionId the ID of the partition on which to acknowledge
+   * @param position the position up to which they should be acknowledged
+   */
+  void acknowledge(final int partitionId, final long position);
 
   /**
    * A helper class to build {@link ContainerEngine} instances. A fresh, non-configured builder will
@@ -170,8 +171,20 @@ public interface ContainerEngine extends Startable, ZeebeTestEngine {
      *
      * @param port the port to assign to the receiver
      * @return itself for chaining
+     * @deprecated since 3.5.2, will be removed in 3.7.0; use {@link
+     *     #withDebugReceiver(DebugReceiver)} instead
      */
+    @Deprecated
     Builder withDebugReceiverPort(final int port);
+
+    /**
+     * The pre-configured {@link DebugReceiver} instance to use. Useful if you want to pre-assign
+     * ports or have fine-grained control over the acknowledgment process.
+     *
+     * @param receiver the debug receiver to use
+     * @return itself for chaining
+     */
+    Builder withDebugReceiver(final DebugReceiver receiver);
 
     /**
      * Builds a {@link ContainerEngine} based on the configuration. If nothing else was called, will

--- a/engine/src/main/java/io/zeebe/containers/engine/ContainerEngine.java
+++ b/engine/src/main/java/io/zeebe/containers/engine/ContainerEngine.java
@@ -21,11 +21,12 @@ import io.zeebe.containers.ZeebeBrokerNode;
 import io.zeebe.containers.ZeebeGatewayNode;
 import io.zeebe.containers.cluster.ZeebeCluster;
 import io.zeebe.containers.exporter.DebugReceiver;
-import java.time.Duration;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.lifecycle.Startable;
+
+import java.time.Duration;
 
 /**
  * A {@link ContainerEngine} is a {@link ZeebeTestEngine} implementation which wraps a container or
@@ -162,7 +163,9 @@ public interface ContainerEngine extends Startable, ZeebeTestEngine {
      *
      * @param acknowledge whether to automatically acknowledge exported records or not
      * @return itself for chaining
+     * @deprecated since 3.5.2, will be removed in 3.7.0; use {@link #withDebugReceiver(DebugReceiver)} instead
      */
+    @Deprecated
     Builder withAutoAcknowledge(final boolean acknowledge);
 
     /**

--- a/engine/src/main/java/io/zeebe/containers/engine/ContainerEngine.java
+++ b/engine/src/main/java/io/zeebe/containers/engine/ContainerEngine.java
@@ -162,7 +162,8 @@ public interface ContainerEngine extends Startable, ZeebeTestEngine {
      *
      * @param acknowledge whether to automatically acknowledge exported records or not
      * @return itself for chaining
-     * @deprecated since 3.5.2, will be removed in 3.7.0; use {@link #withDebugReceiver(DebugReceiver)} instead
+     * @deprecated since 3.5.2, will be removed in 3.7.0; use {@link
+     *     #withDebugReceiver(DebugReceiver)} instead
      */
     @Deprecated
     Builder withAutoAcknowledge(final boolean acknowledge);


### PR DESCRIPTION
## Description

Deprecates setting only the receiver port and allows passing a pre-configured `DebugReceiver`.

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/camunda-cloud/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/camunda-cloud/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
- [ ] Ensure all PR checks are green

