### PR TITLE
refactor(core): expose gateway monitoring port by default

### DIFF
--- a/core/src/main/java/io/zeebe/containers/ZeebeGatewayContainer.java
+++ b/core/src/main/java/io/zeebe/containers/ZeebeGatewayContainer.java
@@ -91,6 +91,11 @@ public class ZeebeGatewayContainer extends GenericContainer<ZeebeGatewayContaine
     applyDefaultConfiguration();
   }
 
+  /** Returns the default topology check, available for overwriting */
+  public static ZeebeTopologyWaitStrategy newDefaultTopologyCheck() {
+    return new ZeebeTopologyWaitStrategy().forBrokersCount(1);
+  }
+
   @Override
   public ZeebeGatewayContainer withTopologyCheck(final ZeebeTopologyWaitStrategy topologyCheck) {
     return waitingFor(
@@ -112,11 +117,9 @@ public class ZeebeGatewayContainer extends GenericContainer<ZeebeGatewayContaine
         .withEnv("ZEEBE_GATEWAY_CLUSTER_HOST", getInternalHost())
         .withEnv("ZEEBE_STANDALONE_GATEWAY", "true")
         .withStartupTimeout(DEFAULT_STARTUP_TIMEOUT)
-        .addExposedPorts(ZeebePort.GATEWAY.getPort(), ZeebePort.INTERNAL.getPort());
-  }
-
-  /** Returns the default topology check, available for overwriting */
-  public static ZeebeTopologyWaitStrategy newDefaultTopologyCheck() {
-    return new ZeebeTopologyWaitStrategy().forBrokersCount(1);
+        .addExposedPorts(
+            ZeebePort.GATEWAY.getPort(),
+            ZeebePort.INTERNAL.getPort(),
+            ZeebePort.MONITORING.getPort());
   }
 }


### PR DESCRIPTION
## Description

This PR exposes the gateway's monitoring port by default, since it's quite useful to access actuators for testing.

## Related issues

closes #332 

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/camunda-cloud/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/camunda-cloud/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
- [ ] Ensure all PR checks are green

