### PR TITLE
build: remove jdk8 from ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,7 @@ jobs:
           ./agent &
           ./agent wait
       - uses: actions/checkout@v3
-      # remove exports causing issues on JDK 8
-      - run: rm .mvn/jvm.config
-      - name: Setup JDK 17 for exporter build
+      - name: Setup Java
         uses: actions/setup-java@v3
         with:
           java-version: '17'
@@ -31,11 +29,6 @@ jobs:
       - name: Build & Copy exporter
         run: >
           mvn -B -T1C -DskipTests -DskipChecks install
-      - name: Set up JDK 8
-        uses: actions/setup-java@v3
-        with:
-          java-version: '8'
-          distribution: 'temurin'
       - name: Test
         timeout-minutes: 20
         run: >
@@ -52,9 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      # remove exports causing issues on JDK 8
-      - run: rm .mvn/jvm.config
-      - name: Setup JDK 17 for exporter build
+      - name: Setup JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: '17'
@@ -63,12 +54,6 @@ jobs:
       - name: Build & Copy exporter
         run: >
           mvn -B -T1C -DskipTests -DskipChecks install
-      - name: Set up JDK 8
-        uses: actions/setup-java@v3
-        with:
-          java-version: '8'
-          distribution: 'temurin'
-          cache: 'maven'
       - name: Test
         timeout-minutes: 20
         # cannot run tests in parallel when using the local daemon
@@ -95,9 +80,7 @@ jobs:
           ./agent &
           ./agent wait
       - uses: actions/checkout@v3
-      # remove exports causing issues on JDK 8
-      - run: rm .mvn/jvm.config
-      - name: Setup JDK 17 for exporter build
+      - name: Setup JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: '17'
@@ -106,11 +89,6 @@ jobs:
       - name: Build & Copy exporter
         run: >
           mvn -B -T1C -DskipTests -DskipChecks install
-      - name: Set up JDK 8
-        uses: actions/setup-java@v3
-        with:
-          java-version: '8'
-          distribution: 'temurin'
       - name: Test
         timeout-minutes: 20
         run: >

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
     <!-- fix minimum JDK version to 8 -->
-    <version.java>1.8</version.java>
+    <version.java>8</version.java>
 
     <!-- disable jdk8 javadoc checks on release build -->
     <additionalparam>-Xdoclint:none</additionalparam>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
     <!-- fix minimum JDK version to 8 -->
-    <version.java>1.8</version.java>
+    <version.java>8</version.java>
 
     <!-- disable jdk8 javadoc checks on release build -->
     <additionalparam>-Xdoclint:none</additionalparam>

--- a/pom.xml
+++ b/pom.xml
@@ -419,6 +419,7 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${plugin.version.compiler}</version>
           <configuration combine.children="append">
+            <release>${version.java}</release>
             <!-- setting it to true unfortunately causes us to recompile every time -->
             <useIncrementalCompilation>false</useIncrementalCompilation>
           </configuration>


### PR DESCRIPTION
## Description

Removes JDK 8 from CI.

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/camunda-cloud/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/camunda-cloud/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
- [ ] Ensure all PR checks are green

