### PR TITLE
fix: apply default start timeout every time

### DIFF
--- a/core/src/main/java/io/zeebe/containers/ZeebeBrokerContainer.java
+++ b/core/src/main/java/io/zeebe/containers/ZeebeBrokerContainer.java
@@ -80,22 +80,6 @@ public class ZeebeBrokerContainer extends GenericContainer<ZeebeBrokerContainer>
     applyDefaultConfiguration();
   }
 
-  private void applyDefaultConfiguration() {
-    withNetwork(Network.SHARED)
-        .waitingFor(
-            new WaitAllStrategy(Mode.WITH_OUTER_TIMEOUT)
-                .withStrategy(new HostPortWaitStrategy())
-                .withStrategy(newDefaultBrokerReadyCheck()))
-        .withStartupTimeout(DEFAULT_STARTUP_TIMEOUT)
-        .withEnv("ZEEBE_BROKER_GATEWAY_ENABLE", "false")
-        .withEnv("ZEEBE_BROKER_NETWORK_HOST", "0.0.0.0")
-        .withEnv("ZEEBE_BROKER_NETWORK_ADVERTISEDHOST", getInternalHost())
-        .addExposedPorts(
-            ZeebePort.COMMAND.getPort(),
-            ZeebePort.INTERNAL.getPort(),
-            ZeebePort.MONITORING.getPort());
-  }
-
   /**
    * Creates a new {@link HttpWaitStrategy} configured for the default broker ready check. Available
    * publicly to be modified as desired.
@@ -108,5 +92,24 @@ public class ZeebeBrokerContainer extends GenericContainer<ZeebeBrokerContainer>
         .forPort(ZeebePort.MONITORING.getPort())
         .forStatusCode(204)
         .withReadTimeout(Duration.ofSeconds(10));
+  }
+
+  private WaitAllStrategy newDefaultWaitStrategy() {
+    return new WaitAllStrategy(Mode.WITH_OUTER_TIMEOUT)
+        .withStrategy(new HostPortWaitStrategy())
+        .withStrategy(newDefaultBrokerReadyCheck())
+        .withStartupTimeout(DEFAULT_STARTUP_TIMEOUT);
+  }
+
+  private void applyDefaultConfiguration() {
+    withNetwork(Network.SHARED)
+        .waitingFor(newDefaultWaitStrategy())
+        .withEnv("ZEEBE_BROKER_GATEWAY_ENABLE", "false")
+        .withEnv("ZEEBE_BROKER_NETWORK_HOST", "0.0.0.0")
+        .withEnv("ZEEBE_BROKER_NETWORK_ADVERTISEDHOST", getInternalHost())
+        .addExposedPorts(
+            ZeebePort.COMMAND.getPort(),
+            ZeebePort.INTERNAL.getPort(),
+            ZeebePort.MONITORING.getPort());
   }
 }

--- a/core/src/main/java/io/zeebe/containers/ZeebeContainer.java
+++ b/core/src/main/java/io/zeebe/containers/ZeebeContainer.java
@@ -88,7 +88,8 @@ public class ZeebeContainer extends GenericContainer<ZeebeContainer>
   protected WaitAllStrategy newDefaultWaitStrategy() {
     return new WaitAllStrategy(Mode.WITH_OUTER_TIMEOUT)
         .withStrategy(new HostPortWaitStrategy())
-        .withStrategy(ZeebeBrokerContainer.newDefaultBrokerReadyCheck());
+        .withStrategy(ZeebeBrokerContainer.newDefaultBrokerReadyCheck())
+        .withStartupTimeout(DEFAULT_STARTUP_TIMEOUT);
   }
 
   private void applyDefaultConfiguration() {
@@ -97,7 +98,6 @@ public class ZeebeContainer extends GenericContainer<ZeebeContainer>
         .withEnv("ZEEBE_BROKER_GATEWAY_ENABLE", "true")
         .withEnv("ZEEBE_BROKER_NETWORK_HOST", "0.0.0.0")
         .withEnv("ZEEBE_BROKER_NETWORK_ADVERTISEDHOST", getInternalHost())
-        .withStartupTimeout(DEFAULT_STARTUP_TIMEOUT)
         .addExposedPorts(
             ZeebePort.GATEWAY.getPort(),
             ZeebePort.COMMAND.getPort(),

--- a/core/src/main/java/io/zeebe/containers/ZeebeGatewayContainer.java
+++ b/core/src/main/java/io/zeebe/containers/ZeebeGatewayContainer.java
@@ -98,15 +98,12 @@ public class ZeebeGatewayContainer extends GenericContainer<ZeebeGatewayContaine
 
   @Override
   public ZeebeGatewayContainer withTopologyCheck(final ZeebeTopologyWaitStrategy topologyCheck) {
-    return waitingFor(
-        new WaitAllStrategy(Mode.WITH_OUTER_TIMEOUT)
-            .withStrategy(new HostPortWaitStrategy())
-            .withStrategy(topologyCheck));
+    return waitingFor(newDefaultWaitStrategy(topologyCheck));
   }
 
   @Override
   public ZeebeGatewayContainer withoutTopologyCheck() {
-    return waitingFor(new HostPortWaitStrategy());
+    return waitingFor(new HostPortWaitStrategy().withStartupTimeout(DEFAULT_STARTUP_TIMEOUT));
   }
 
   private void applyDefaultConfiguration() {
@@ -121,5 +118,12 @@ public class ZeebeGatewayContainer extends GenericContainer<ZeebeGatewayContaine
             ZeebePort.GATEWAY.getPort(),
             ZeebePort.INTERNAL.getPort(),
             ZeebePort.MONITORING.getPort());
+  }
+
+  private WaitAllStrategy newDefaultWaitStrategy(ZeebeTopologyWaitStrategy topologyCheck) {
+    return new WaitAllStrategy(Mode.WITH_OUTER_TIMEOUT)
+        .withStrategy(new HostPortWaitStrategy())
+        .withStrategy(topologyCheck)
+        .withStartupTimeout(DEFAULT_STARTUP_TIMEOUT);
   }
 }


### PR DESCRIPTION
## Description

Applies the default start time out to all strategies.

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/camunda-cloud/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/camunda-cloud/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
- [ ] Ensure all PR checks are green

