### PR TITLE
refactor: bump to Java 21

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,10 +13,10 @@ jobs:
       artifacts_archive_path: ${{ steps.release.outputs.artifacts_archive_path }}
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
           gpg-private-key: ${{ secrets.MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
       - name: Check
@@ -32,11 +32,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3.3.0
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
           cache: 'maven'
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
       - name: Build & Copy exporter
@@ -45,10 +45,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Setup JDK 17
+      - name: Setup JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
       - name: Build & Copy exporter
@@ -80,10 +80,10 @@ jobs:
           ./agent &
           ./agent wait
       - uses: actions/checkout@v4
-      - name: Setup JDK 17
+      - name: Setup JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
       - name: Build & Copy exporter
@@ -105,10 +105,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
       - name: Build

--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ testImplementation 'io.zeebe:zeebe-test-container:3.5.0'
 
 Zeebe Test Container is built for Java 8+, and will not work on lower Java versions.
 
-> You will need Java 17+ for development purposes, however, as many of our tests rely on shared
-> Zeebe libraries which are built for Java 17+.
+> You will need Java 21+ for development purposes, however, as many of our tests rely on shared
+> Zeebe libraries which are built for Java 21+.
 
 Additionally, you will need to comply with all the Testcontainers requirements, as defined
 [here](https://www.testcontainers.org/#prerequisites).
@@ -1178,7 +1178,7 @@ you will need to sign the [Contributor License Agreement](https://cla-assistant.
 In order to build from source, you will need to install maven 3.6+. You can find more about it on
 the [maven homepage](https://maven.apache.org/users/index.html).
 
-To build the project, you will need a JDK 17 installed locally. Note however that the `core` and `engine` modules
+To build the project, you will need a JDK 21 installed locally. Note however that the `core` and `engine` modules
 are targeting Java 8 for compatibility purposes, and we must ensure that we maintain compatibility.
 To do this, the CI pipeline will run the tests using Java 8.
 
@@ -1194,7 +1194,7 @@ The library is split into three modules:
 - `engine`: the implementation of `ZeebeTestEngine`, the compatibility layer between this library
   and [Zeebe Process Test](https://github.com/camunda/zeebe-process-test).
 - `exporter`: the debug exporter module. It will be packaged as a fat JAR and included as a resource
-  in the core module. It has to be a separate module as it targets Java 17, same as the
+  in the core module. It has to be a separate module as it targets Java 21, same as the
   `zeebe-exporter-api` module it implements.
 - `exporter-test`: a module to test the integration between `DebugReceiver` and `DebugExporter`,
   without having to run everything through an actual broker.

--- a/README.md
+++ b/README.md
@@ -1229,6 +1229,10 @@ Testing is done via GitHub actions, using two workflows:
   tests
   which need to run on the local job should be annotated with `@DisabledIfTestcontainersCloud`.
 
+One important thing to note is that we package and copy the debug exporter into the core module
+during the build process. This means that any tests which relies on the debug exporter being
+accessible has to be an integration test run by failsafe (i.e. test files ending with `IT`).
+
 ## Code style
 
 The project uses Spotless to apply consistent formatting and licensing to all project files. By

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -201,8 +201,7 @@
             <goals>
               <goal>copy</goal>
             </goals>
-            <!-- TODO: set to package, and run the relevant tests as integration tests -->
-            <phase>generate-resources</phase>
+            <phase>package</phase>
             <configuration>
               <artifactItems>
                 <artifactItem>
@@ -219,6 +218,11 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
       </plugin>
 
       <plugin>

--- a/core/src/test/java/io/zeebe/containers/examples/exporter/BrokerWithDebugExporterIT.java
+++ b/core/src/test/java/io/zeebe/containers/examples/exporter/BrokerWithDebugExporterIT.java
@@ -51,7 +51,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * io.zeebe.containers.ZeebeBrokerNode#withDebugExporter(int)}.
  */
 @Testcontainers
-final class BrokerWithDebugExporterTest {
+final class BrokerWithDebugExporterIT {
   private final List<Record<?>> records = new CopyOnWriteArrayList<>();
   private final DebugReceiver receiver = new DebugReceiver(records::add).start();
 

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -114,6 +114,11 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+      </plugin>
+
+      <plugin>
         <groupId>org.revapi</groupId>
         <artifactId>revapi-maven-plugin</artifactId>
         <version>${plugin.version.revapi}</version>

--- a/engine/src/test/java/io/zeebe/containers/engine/DebugReceiverStreamIT.java
+++ b/engine/src/test/java/io/zeebe/containers/engine/DebugReceiverStreamIT.java
@@ -39,7 +39,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.junit.jupiter.api.Test;
 
-final class DebugReceiverStreamTest {
+final class DebugReceiverStreamIT {
   private final InfiniteList<Record<?>> records = new InfiniteList<>();
   private final DebugReceiver receiver = new DebugReceiver(records::add);
 

--- a/engine/src/test/java/io/zeebe/containers/engine/examples/ClusterEngineExampleIT.java
+++ b/engine/src/test/java/io/zeebe/containers/engine/examples/ClusterEngineExampleIT.java
@@ -31,7 +31,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
-final class ClusterEngineExampleTest {
+final class ClusterEngineExampleIT {
   private final Network network = Network.newNetwork();
 
   // a container which will print out its log to the given logger

--- a/engine/src/test/java/io/zeebe/containers/engine/examples/ContainerEngineExampleIT.java
+++ b/engine/src/test/java/io/zeebe/containers/engine/examples/ContainerEngineExampleIT.java
@@ -45,8 +45,8 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * href="https://github.com/camunda/zeebe-process-test">zeebe-process-test</a>.
  */
 @Testcontainers
-final class ContainerEngineExampleTest {
-  private static final Logger LOGGER = LoggerFactory.getLogger(ContainerEngineExampleTest.class);
+final class ContainerEngineExampleIT {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ContainerEngineExampleIT.class);
 
   // a container which will print out its log to the given logger
   private final ZeebeContainer container =

--- a/engine/src/test/java/io/zeebe/containers/engine/examples/GracePeriodExampleIT.java
+++ b/engine/src/test/java/io/zeebe/containers/engine/examples/GracePeriodExampleIT.java
@@ -37,7 +37,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * of the grace period, thus slowing down your tests.
  */
 @Testcontainers
-final class GracePeriodExampleTest {
+final class GracePeriodExampleIT {
   @Container
   private final ContainerEngine engine =
       ContainerEngine.builder().withGracePeriod(Duration.ofSeconds(5)).build();

--- a/exporter-test/pom.xml
+++ b/exporter-test/pom.xml
@@ -14,8 +14,8 @@
   <name>Zeebe Test Container Exporter Tests</name>
 
   <properties>
-    <!-- fix minimum JDK to 17, meaning the exporter is not compatible with Zeebe < 8.x -->
-    <version.java>17</version.java>
+    <!-- fix minimum JDK to 21, meaning the exporter is not compatible with Zeebe < 8.4 -->
+    <version.java>21</version.java>
   </properties>
 
   <dependencies>

--- a/exporter/pom.xml
+++ b/exporter/pom.xml
@@ -14,8 +14,8 @@
   <name>Zeebe Test Container Exporter</name>
 
   <properties>
-    <!-- fix minimum JDK to 17, meaning the exporter is not compatible with Zeebe < 8.x -->
-    <version.java>17</version.java>
+    <!-- fix minimum JDK to 21, meaning the exporter is not compatible with Zeebe < 8.4 -->
+    <version.java>21</version.java>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
   <properties>
     <!-- release parent settings -->
-    <version.java>17</version.java>
+    <version.java>21</version.java>
     <nexus.snapshot.repository>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/</nexus.snapshot.repository>
     <nexus.release.repository>https://artifacts.camunda.com/artifactory/zeebe-io/</nexus.release.repository>
 

--- a/pom.xml
+++ b/pom.xml
@@ -610,6 +610,7 @@
                 <!-- dependencies not directly used in all projects during tests -->
                 <ignoredUnusedDeclaredDependencies combine.children="append">
                   <dep>org.slf4j:slf4j-simple</dep>
+                  <dep>org.junit.jupiter:junit-jupiter</dep>
                 </ignoredUnusedDeclaredDependencies>
               </configuration>
             </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
     <plugin.version.compiler>3.11.0</plugin.version.compiler>
     <plugin.version.dependency>3.6.0</plugin.version.dependency>
     <plugin.version.enforcer>3.4.1</plugin.version.enforcer>
+    <plugin.version.failsafe>3.2.2</plugin.version.failsafe>
     <plugin.version.flatten>1.5.0</plugin.version.flatten>
     <plugin.version.google-format>1.17.0</plugin.version.google-format>
     <plugin.version.gpg>3.1.0</plugin.version.gpg>
@@ -370,6 +371,13 @@
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${version.junit-jupiter}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>
@@ -531,6 +539,25 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${plugin.version.surefire}</version>
+          <configuration>
+            <failIfNoTests>false</failIfNoTests>
+            <trimStackTrace>false</trimStackTrace>
+            <redirectTestOutputToFile>true</redirectTestOutputToFile>
+          </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>org.junit.jupiter</groupId>
+              <artifactId>junit-jupiter-engine</artifactId>
+              <version>${version.junit-jupiter}</version>
+            </dependency>
+          </dependencies>
+        </plugin>
+
+        <!-- integration tests -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>${plugin.version.failsafe}</version>
           <configuration>
             <failIfNoTests>false</failIfNoTests>
             <trimStackTrace>false</trimStackTrace>
@@ -768,22 +795,39 @@
         <forkCount>1C</forkCount>
       </properties>
       <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <forkCount>${forkCount}</forkCount>
-              <reuseForks>true</reuseForks>
-              <properties>
-                <configurationParameters>junit.jupiter.execution.parallel.enabled = true
-                  junit.jupiter.execution.parallel.mode.default = concurrent
-                  junit.jupiter.execution.parallel.config.strategy = fixed
-                  junit.jupiter.execution.parallel.config.fixed.parallelism = 2</configurationParameters>
-              </properties>
-            </configuration>
-          </plugin>
-        </plugins>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                <forkCount>${forkCount}</forkCount>
+                <reuseForks>true</reuseForks>
+                <properties>
+                  <configurationParameters>junit.jupiter.execution.parallel.enabled = true
+                    junit.jupiter.execution.parallel.mode.default = concurrent
+                    junit.jupiter.execution.parallel.config.strategy = fixed
+                    junit.jupiter.execution.parallel.config.fixed.parallelism = 2</configurationParameters>
+                </properties>
+              </configuration>
+            </plugin>
+
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-failsafe-plugin</artifactId>
+              <configuration>
+                <forkCount>${forkCount}</forkCount>
+                <reuseForks>true</reuseForks>
+                <properties>
+                  <configurationParameters>junit.jupiter.execution.parallel.enabled = true
+                    junit.jupiter.execution.parallel.mode.default = concurrent
+                    junit.jupiter.execution.parallel.config.strategy = fixed
+                    junit.jupiter.execution.parallel.config.fixed.parallelism = 2</configurationParameters>
+                </properties>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
       </build>
     </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <plugin.version.dependency>3.6.0</plugin.version.dependency>
     <plugin.version.enforcer>3.4.1</plugin.version.enforcer>
     <plugin.version.flatten>1.5.0</plugin.version.flatten>
-    <plugin.version.google-format>1.15.0</plugin.version.google-format>
+    <plugin.version.google-format>1.17.0</plugin.version.google-format>
     <plugin.version.gpg>3.1.0</plugin.version.gpg>
     <plugin.version.jar>3.3.0</plugin.version.jar>
     <plugin.version.javadoc>3.6.2</plugin.version.javadoc>


### PR DESCRIPTION
## Description

Bump zeebe-test-container to use Java 21 since it relies on some Zeebe internals which are also on 21 at this point.

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/camunda-cloud/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/camunda-cloud/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
- [ ] Ensure all PR checks are green

