### PR TITLE
refactor: downgrade exporter to 17 for < 8.4 compat

### DIFF
--- a/exporter/pom.xml
+++ b/exporter/pom.xml
@@ -14,8 +14,8 @@
   <name>Zeebe Test Container Exporter</name>
 
   <properties>
-    <!-- fix minimum JDK to 21, meaning the exporter is not compatible with Zeebe < 8.4 -->
-    <version.java>21</version.java>
+    <!-- fix minimum JDK to 17, meaning the exporter is not compatible with Zeebe < 8.x -->
+    <version.java>17</version.java>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -480,7 +480,9 @@
               <includes>
                 <include>**/*.md</include>
               </includes>
-
+              <excludes>
+                <exclude>**/target/**/*.md</exclude>
+              </excludes>
               <flexmark/>
             </markdown>
           </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>community-hub-release-parent</artifactId>
     <version>1.4.4</version>
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
-    <relativePath />
+    <relativePath/>
   </parent>
 
   <groupId>io.zeebe</groupId>
@@ -481,7 +481,7 @@
                 <include>**/*.md</include>
               </includes>
 
-              <flexmark />
+              <flexmark/>
             </markdown>
           </configuration>
           <executions>
@@ -529,7 +529,7 @@
                 <goal>check</goal>
               </goals>
               <phase>validate</phase>
-              <configuration />
+              <configuration/>
             </execution>
           </executions>
         </plugin>
@@ -664,7 +664,7 @@
               <configuration>
                 <!-- see more https://maven.apache.org/enforcer/enforcer-rules/index.html -->
                 <rules>
-                  <banDuplicatePomDependencyVersions />
+                  <banDuplicatePomDependencyVersions/>
                 </rules>
               </configuration>
             </execution>


### PR DESCRIPTION
## Description

This PR downgrades the exporter from Java 21 to Java 17 to keep compatibility with versions < 8.4.

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/camunda-cloud/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/camunda-cloud/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
- [ ] Ensure all PR checks are green

