### PR TITLE
fix: automatically cleanup `ZeebeVolume`s

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>community-hub-release-parent</artifactId>
     <version>1.4.4</version>
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
-    <relativePath />
+    <relativePath/>
   </parent>
 
   <groupId>io.zeebe</groupId>
@@ -483,7 +483,7 @@
               <excludes>
                 <exclude>**/target/**/*.md</exclude>
               </excludes>
-              <flexmark />
+              <flexmark/>
             </markdown>
           </configuration>
           <executions>
@@ -531,7 +531,7 @@
                 <goal>check</goal>
               </goals>
               <phase>validate</phase>
-              <configuration />
+              <configuration/>
             </execution>
           </executions>
         </plugin>
@@ -666,7 +666,7 @@
               <configuration>
                 <!-- see more https://maven.apache.org/enforcer/enforcer-rules/index.html -->
                 <rules>
-                  <banDuplicatePomDependencyVersions />
+                  <banDuplicatePomDependencyVersions/>
                 </rules>
               </configuration>
             </execution>


### PR DESCRIPTION
Accesses the internal of testcontainers-java to apply the correct label to `ZeebeVolume`s such that Ryuk (or an alternative `ResourceReaper`) can find the volume and automatically remove it after tests are done.

The tests are a bit hacky because we use reflection to get to the private implementations of `ResourceReaper`.

Closes #656 