### PR TITLE
Fix compatibility with Apache httpcore5 5.2.5 by adding a virtual host for Testcontainers' proxy

### DIFF
--- a/core/src/main/java/io/zeebe/containers/ZeebeBrokerNode.java
+++ b/core/src/main/java/io/zeebe/containers/ZeebeBrokerNode.java
@@ -105,7 +105,7 @@ public interface ZeebeBrokerNode<T extends GenericContainer<T> & ZeebeBrokerNode
             "ZEEBE_BROKER_EXPORTERS_DEBUG_CLASSNAME", "io.zeebe.containers.exporter.DebugExporter")
         .withEnv(
             "ZEEBE_BROKER_EXPORTERS_DEBUG_ARGS_URL",
-            "http://host.testcontainers.internal:" + containerPort + "/records");
+            GenericContainer.INTERNAL_HOST_HOSTNAME + ":" + containerPort + "/records");
 
     return self();
   }

--- a/core/src/main/java/io/zeebe/containers/exporter/DebugReceiver.java
+++ b/core/src/main/java/io/zeebe/containers/exporter/DebugReceiver.java
@@ -36,6 +36,7 @@ import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
 
 /**
  * Receives records sent from one or more debug exporter instances. The receiver will start an HTTP
@@ -257,7 +258,10 @@ public final class DebugReceiver implements AutoCloseable {
         .setIOReactorConfig(config)
         .setCanonicalHostName("localhost")
         .setCharCodingConfig(CharCodingConfig.custom().setCharset(StandardCharsets.UTF_8).build())
-        .setHttpProcessor(HttpProcessors.server("zpt-debug/1.1"))
+        .setHttpProcessor(HttpProcessors.server("ztc-debug/1.1"))
+        // need to register the handler on both the primary and possibly Testcontainers' proxy for
+        // our local server, as otherwise the requests with hosts that do not match will be skipped
+        .registerVirtual(GenericContainer.INTERNAL_HOST_HOSTNAME, "/records", recordHandler)
         .register("/records", recordHandler)
         .create();
   }

--- a/core/src/main/java/io/zeebe/containers/exporter/RecordHandler.java
+++ b/core/src/main/java/io/zeebe/containers/exporter/RecordHandler.java
@@ -22,10 +22,10 @@ import io.camunda.zeebe.protocol.jackson.ZeebeProtocolModule;
 import io.camunda.zeebe.protocol.record.Record;
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import org.apache.hc.core5.http.EntityDetails;
 import org.apache.hc.core5.http.HttpException;
@@ -72,7 +72,7 @@ final class RecordHandler implements AsyncServerRequestHandler<Message<HttpReque
 
   private final Consumer<Record<?>> recordConsumer;
   private final boolean autoAcknowledge;
-  private final Map<Integer, Long> positions = new HashMap<>();
+  private final Map<Integer, Long> positions = new ConcurrentHashMap<>();
 
   RecordHandler(final Consumer<Record<?>> recordConsumer, final boolean autoAcknowledge) {
     this.recordConsumer = Objects.requireNonNull(recordConsumer, "must specify a record consumer");

--- a/exporter/src/main/java/io/zeebe/containers/exporter/DebugExporter.java
+++ b/exporter/src/main/java/io/zeebe/containers/exporter/DebugExporter.java
@@ -135,7 +135,7 @@ public final class DebugExporter implements Exporter {
         .header("Content-Type", JSON_MIME_TYPE)
         .header("Accept", JSON_MIME_TYPE)
         .header("charset", "utf-8")
-        .header("User-Agent", "zpt-debug-exporter/4.0.0")
+        .header("User-Agent", "ztc-debug-exporter/4.0.0")
         .timeout(Duration.ofSeconds(5))
         .POST(
             BodyPublishers.ofByteArray(MAPPER.writeValueAsBytes(Collections.singletonList(record))))

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <version.docker>3.3.6</version.docker>
     <version.duct-tape>1.0.8</version.duct-tape>
     <version.feign>13.2.1</version.feign>
-    <version.httpcore5>5.2.4</version.httpcore5>
+    <version.httpcore5>5.2.5</version.httpcore5>
     <version.jackson>2.17.1</version.jackson>
     <version.jcip>1.0</version.jcip>
     <version.junit-jupiter>5.10.3</version.junit-jupiter>


### PR DESCRIPTION
## Description

With Apach HTTPComponents httpcore5 5.2.5, the server now matches the request authority, which causes it to drop when the host name is not recognized. This breaks the DebugExporter which uses the internal Testcontainers proxy (`host.testcontainers.org`), whereas the server is expecting `localhost`. The simple fix is to support both access patterns by adding a virtual host, and having both use the same handler (which is already thread-safe, assuming the given consumer is also thread-safe).

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/camunda-cloud/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/camunda-cloud/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
- [ ] Ensure all PR checks are green

