### PR TITLE
feat: add support for REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,8 @@ public class MyFeatureTest {
     // given
     final ZeebeClient client =
       ZeebeClient.newClientBuilder()
-        .gatewayAddress(zeebeContainer.getExternalGatewayAddress())
+        .grpcAddress(zeebeContainer.getGrpcAddress())
+        .restAddress(zeebeContainer.getRestAddress())
         .usePlaintext()
         .build();
     final BpmnModelInstance process =
@@ -249,7 +250,8 @@ public class MyFeatureTest {
     // given
     final ZeebeClient client =
       ZeebeClient.newClientBuilder()
-        .gatewayAddress(zeebeContainer.getExternalGatewayAddress())
+        .grpcAddress(zeebeContainer.getGrpcAddress())
+        .restAddress(zeebeContainer.getRestAddress())
         .usePlaintext()
         .build();
     final BpmnModelInstance process =
@@ -309,7 +311,7 @@ The container is considered started if and only if:
 > A topology is considered complete if there is a leader for all partitions.
 
 Once started, the container is ready to accept commands, and a client can connect to it by setting
-its `gatewayAddress` to `ZeebeContainer#getExternalGatewayAddress()`.
+its `grpcAddress` to `ZeebeContainer#getGrpcAddress()`, and its `restAddress` to `ZeebeContainer#getRestAddress()`.
 
 ## Standalone broker without gateway
 
@@ -348,7 +350,7 @@ The container is considered started if and only if:
 > A topology is considered complete if there is a leader for all partitions.
 
 Once started, the container is ready to accept commands, and a client can connect to it by setting
-its `gatewayAddress` to `ZeebeContainer#getExternalGatewayAddress()`.
+its `grpcAddress` to `ZeebeContainer#getGrpcAddress()`, and its `restAddress` to `ZeebeContainer#getRestAddress()`.
 
 ## Configuring your container
 

--- a/core/src/main/java/io/zeebe/containers/ZeebeContainer.java
+++ b/core/src/main/java/io/zeebe/containers/ZeebeContainer.java
@@ -99,7 +99,8 @@ public class ZeebeContainer extends GenericContainer<ZeebeContainer>
         .withEnv("ZEEBE_BROKER_NETWORK_HOST", "0.0.0.0")
         .withEnv("ZEEBE_BROKER_NETWORK_ADVERTISEDHOST", getInternalHost())
         .addExposedPorts(
-            ZeebePort.GATEWAY.getPort(),
+            ZeebePort.GATEWAY_REST.getPort(),
+            ZeebePort.GATEWAY_GRPC.getPort(),
             ZeebePort.COMMAND.getPort(),
             ZeebePort.INTERNAL.getPort(),
             ZeebePort.MONITORING.getPort());

--- a/core/src/main/java/io/zeebe/containers/ZeebeGatewayContainer.java
+++ b/core/src/main/java/io/zeebe/containers/ZeebeGatewayContainer.java
@@ -116,7 +116,8 @@ public class ZeebeGatewayContainer extends GenericContainer<ZeebeGatewayContaine
         .withEnv("ZEEBE_STANDALONE_GATEWAY", "true")
         .withStartupTimeout(DEFAULT_STARTUP_TIMEOUT)
         .addExposedPorts(
-            ZeebePort.GATEWAY.getPort(),
+            ZeebePort.GATEWAY_REST.getPort(),
+            ZeebePort.GATEWAY_GRPC.getPort(),
             ZeebePort.INTERNAL.getPort(),
             ZeebePort.MONITORING.getPort());
   }

--- a/core/src/main/java/io/zeebe/containers/ZeebeGatewayContainer.java
+++ b/core/src/main/java/io/zeebe/containers/ZeebeGatewayContainer.java
@@ -56,13 +56,14 @@ import org.testcontainers.utility.DockerImageName;
  *
  * <pre>{@code
  * ZeebeClient.newClientBuilder()
- *   .brokerContainerPoint(container.getExternalGatewayAddress())
+ *   .grpcAddress(container.getGrpcAddress())
+ *   .restAddress(container.getRestAddress())
  *   .usePlaintext()
  *   .build();
  * }</pre>
  *
  * <p>Note that if your client is also a container within the same network, you can and should use
- * the {@link #getInternalGatewayAddress()}.
+ * the {@link #getInternalGrpcAddress()} and {@link #getInternalRestAddress()} variants.
  */
 @API(status = Status.STABLE)
 @SuppressWarnings({"WeakerAccess", "UnusedReturnValue"})

--- a/core/src/main/java/io/zeebe/containers/ZeebeGatewayNode.java
+++ b/core/src/main/java/io/zeebe/containers/ZeebeGatewayNode.java
@@ -15,11 +15,10 @@
  */
 package io.zeebe.containers;
 
+import java.net.URI;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 import org.testcontainers.containers.GenericContainer;
-
-import java.net.URI;
 
 /**
  * Represents common properties of nodes which can act as a gateway for a Zeebe cluster, e.g. {@link

--- a/core/src/main/java/io/zeebe/containers/ZeebeGatewayNode.java
+++ b/core/src/main/java/io/zeebe/containers/ZeebeGatewayNode.java
@@ -19,15 +19,16 @@ import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 import org.testcontainers.containers.GenericContainer;
 
+import java.net.URI;
+
 /**
  * Represents common properties of nodes which can act as a gateway for a Zeebe cluster, e.g. {@link
  * ZeebeContainer} or {@link ZeebeGatewayContainer}.
  *
- * <p>You can use {@link #getExternalGatewayAddress()} for clients which are not part of the gateway
- * container's network; this is most likely what you want to use, so when in doubt use this.
- *
- * <p>You can use {@link #getInternalGatewayAddress()} for clients which are within the gateway
- * container's network.
+ * <p>You should typically use {@link #getGrpcAddress()} and {@link #getRestAddress()} to wire your
+ * clients with this gateway. If your client happens to be running in the same network as the Docker
+ * container, then you may want to use {@link #getInternalGrpcAddress()} or {@link
+ * #getInternalRestAddress()} instead.
  *
  * @param <T> the concrete type of the underlying container
  */
@@ -73,13 +74,16 @@ public interface ZeebeGatewayNode<T extends GenericContainer<T> & ZeebeGatewayNo
    *
    * <pre>@{code
    *   ZeebeClient.newClientBuilder()
-   *     .withBrokerContactPoint(container.getExternalGatewayAddress())
+   *     .gatewayAddress(container.getExternalGatewayAddress())
    *     .usePlaintext()
    *     .build();
    * }</pre>
    *
    * @return the gateway address visible from outside the docker network
+   * @deprecated Use the protocol specific variants from now on, {@link #getGrpcAddress()} or {@link
+   *     #getRestAddress()}
    */
+  @Deprecated
   default String getExternalGatewayAddress() {
     return getExternalAddress(ZeebePort.GATEWAY.getPort());
   }
@@ -91,14 +95,185 @@ public interface ZeebeGatewayNode<T extends GenericContainer<T> & ZeebeGatewayNo
    *
    * <pre>@{code
    *   ZeebeClient.newClientBuilder()
-   *     .withBrokerContactPoint(container.getInternalGatewayAddress())
+   *     .gatewayAddress(container.getInternalGatewayAddress())
    *     .usePlaintext()
    *     .build();
    * }</pre>
    *
    * @return the gateway address visible from within the docker network
+   * @deprecated Use the protocol specific variants from now on, {@link #getInternalGrpcAddress()}
+   *     or {@link #getInternalRestAddress()}
    */
+  @Deprecated
   default String getInternalGatewayAddress() {
     return getInternalAddress(ZeebePort.GATEWAY.getPort());
+  }
+
+  /**
+   * Returns an address accessible from within the container's network for the REST API. Primarily
+   * meant to be used by clients.
+   *
+   * <p>You can build your client like this:
+   *
+   * <pre>@{code
+   *   ZeebeClient.newClientBuilder()
+   *     .restAddress(container.getInternalRestUrl())
+   *     .usePlaintext()
+   *     .build();
+   * }</pre>
+   *
+   * @return internally accessible REST API address
+   */
+  default URI getInternalRestAddress() {
+    return getInternalRestAddress("http");
+  }
+
+  /**
+   * Returns an address accessible from within the container's network for the REST API. Primarily
+   * meant to be used by clients.
+   *
+   * <p>Use this variant if you need to specify a different scheme, e.g. HTTPS.
+   *
+   * <p>You can build your client like this:
+   *
+   * <pre>@{code
+   *   ZeebeClient.newClientBuilder()
+   *     .restAddress(container.getInternalRestUrl("https"))
+   *     .build();
+   * }</pre>
+   *
+   * @param scheme the expected scheme (e.g. HTTP, HTTPS)
+   * @return internally accessible REST API address
+   */
+  default URI getInternalRestAddress(final String scheme) {
+    final int port = ZeebePort.GATEWAY_REST.getPort();
+    return URI.create(String.format("%s://%s:%d", scheme, getInternalHost(), port));
+  }
+
+  /**
+   * Returns the address of the REST API a client which is not part of the container's network
+   * should use. If you want an address accessible from within the container's own network, use *
+   * {@link #getInternalRestAddress()}
+   *
+   * <p>You can build your client like this:
+   *
+   * <pre>@{code
+   *   ZeebeClient.newClientBuilder()
+   *     .restAddress(container.getRestAddress())
+   *     .usePlaintext()
+   *     .build();
+   * }</pre>
+   *
+   * @return externally accessible REST API address
+   */
+  default URI getRestAddress() {
+    return getRestAddress("http");
+  }
+
+  /**
+   * Returns the address of the REST API a client which is not part of the container's network
+   * should use. If you want an address accessible from within the container's own network, use
+   * {@link #getInternalRestAddress(String)}.
+   *
+   * <p>Use this method if you need to specify a different connection scheme, e.g. HTTPS.
+   *
+   * <p>You can build your client like this:
+   *
+   * <pre>@{code
+   *   ZeebeClient.newClientBuilder()
+   *     .restAddress(container.getExternalRestAddress("https"))
+   *     .build();
+   * }</pre>
+   *
+   * @param scheme the expected scheme (e.g. HTTP, HTTPS)
+   * @return externally accessible REST API address
+   */
+  default URI getRestAddress(final String scheme) {
+    final int port = getMappedPort(ZeebePort.GATEWAY_REST.getPort());
+    return URI.create(String.format("%s://%s:%d", scheme, getExternalHost(), port));
+  }
+
+  /**
+   * Returns an address accessible from within the container's network for the gRPC API. Primarily
+   * meant to be used by clients.
+   *
+   * <p>You can build your client like this:
+   *
+   * <pre>@{code
+   *   ZeebeClient.newClientBuilder()
+   *     .grpcAddress(container.getInternalGrpcAddress())
+   *     .usePlaintext()
+   *     .build();
+   * }</pre>
+   *
+   * @return internally accessible REST API address
+   */
+  default URI getInternalGrpcAddress() {
+    return getInternalGrpcAddress("http");
+  }
+
+  /**
+   * Returns an address accessible from within the container's network for the REST API. Primarily
+   * meant to be used by clients.
+   *
+   * <p>Use this variant if you need to specify a different scheme, e.g. HTTPS.
+   *
+   * <p>You can build your client like this:
+   *
+   * <pre>@{code
+   *   ZeebeClient.newClientBuilder()
+   *     .grpcAddress(container.getInternalGrpcAddress("https"))
+   *     .build();
+   * }</pre>
+   *
+   * @param scheme the expected scheme (e.g. HTTP, HTTPS)
+   * @return internally accessible REST API address
+   */
+  default URI getInternalGrpcAddress(final String scheme) {
+    final int port = ZeebePort.GATEWAY_REST.getPort();
+    return URI.create(String.format("%s://%s:%d", scheme, getInternalHost(), port));
+  }
+
+  /**
+   * Returns the address of the gRPC API a client which is not part of the container's network
+   * should use. If you want an address accessible from within the container's own network, use
+   * {@link #getInternalGrpcAddress()}.
+   *
+   * <p>You can build your client like this:
+   *
+   * <pre>@{code
+   *   ZeebeClient.newClientBuilder()
+   *     .grpcAddress(container.getGrpcAddress())
+   *     .usePlaintext()
+   *     .build();
+   * }</pre>
+   *
+   * @return externally accessible gRPC API address
+   */
+  default URI getGrpcAddress() {
+    return getGrpcAddress("http");
+  }
+
+  /**
+   * Returns the address of the gRPC API a client which is not part of the container's network
+   * should use. If you want an address accessible from within the container's own network, use
+   * {@link #getInternalGrpcAddress(String)}.
+   *
+   * <p>Use this method if you need to specify a different connection scheme, e.g. HTTPS.
+   *
+   * <p>You can build your client like this:
+   *
+   * <pre>@{code
+   *   ZeebeClient.newClientBuilder()
+   *     .grpcAddress(container.getGrpcAddress("https"))
+   *     .build();
+   * }</pre>
+   *
+   * @param scheme the expected scheme (e.g. HTTP, HTTPS)
+   * @return externally accessible gRPC API address
+   */
+  default URI getGrpcAddress(final String scheme) {
+    final int port = getMappedPort(ZeebePort.GATEWAY_GRPC.getPort());
+    return URI.create(String.format("%s://%s:%d", scheme, getExternalHost(), port));
   }
 }

--- a/core/src/main/java/io/zeebe/containers/ZeebeNode.java
+++ b/core/src/main/java/io/zeebe/containers/ZeebeNode.java
@@ -17,6 +17,7 @@ package io.zeebe.containers;
 
 import java.time.Duration;
 import java.util.List;
+
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 import org.testcontainers.containers.Container;

--- a/core/src/main/java/io/zeebe/containers/ZeebeNode.java
+++ b/core/src/main/java/io/zeebe/containers/ZeebeNode.java
@@ -17,7 +17,6 @@ package io.zeebe.containers;
 
 import java.time.Duration;
 import java.util.List;
-
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 import org.testcontainers.containers.Container;

--- a/core/src/main/java/io/zeebe/containers/ZeebePort.java
+++ b/core/src/main/java/io/zeebe/containers/ZeebePort.java
@@ -23,12 +23,24 @@ import org.apiguardian.api.API.Status;
 public enum ZeebePort {
   /** Port of the command API, i.e. the port used by the gateway to communicate with the broker */
   COMMAND(26501),
-  /** Port of the gateway API, i.e. the port used by the client to communicate with any gateway */
+  /**
+   * Deprecated reference to the old GATEWAY port, which is the gRPC port; use {@link #GATEWAY_REST}
+   * or {@link #GATEWAY_GRPC} in the future
+   */
+  @Deprecated
   GATEWAY(26500),
   /** Port for internal communication, i.e. what all nodes use to communicate for clustering */
   INTERNAL(26502),
   /** Port for the management server, i.e. actuators, metrics, etc. */
-  MONITORING(9600);
+  MONITORING(9600),
+  /**
+   * Port of the gateway REST API, i.e. the port used by the client to communicate with any gateway
+   */
+  GATEWAY_REST(8080),
+  /**
+   * Port of the gateway gRPC API, i.e. the port used by the client to communicate with any gateway
+   */
+  GATEWAY_GRPC(26500);
 
   private final int port;
 

--- a/core/src/main/java/io/zeebe/containers/ZeebeTopologyWaitStrategy.java
+++ b/core/src/main/java/io/zeebe/containers/ZeebeTopologyWaitStrategy.java
@@ -103,7 +103,7 @@ public class ZeebeTopologyWaitStrategy extends AbstractWaitStrategy {
    */
   public ZeebeTopologyWaitStrategy(
       final int brokersCount, final int replicationFactor, final int partitionsCount) {
-    this(brokersCount, replicationFactor, partitionsCount, ZeebePort.GATEWAY.getPort());
+    this(brokersCount, replicationFactor, partitionsCount, ZeebePort.GATEWAY_GRPC.getPort());
   }
 
   /**

--- a/core/src/main/java/io/zeebe/containers/cluster/ZeebeCluster.java
+++ b/core/src/main/java/io/zeebe/containers/cluster/ZeebeCluster.java
@@ -234,7 +234,8 @@ public class ZeebeCluster implements Startable {
     final ZeebeGatewayNode<?> gateway = getAvailableGateway();
 
     return ZeebeClient.newClientBuilder()
-        .gatewayAddress(gateway.getExternalGatewayAddress())
+        .grpcAddress(gateway.getGrpcAddress())
+        .restAddress(gateway.getRestAddress())
         .usePlaintext();
   }
 

--- a/core/src/test/java/io/zeebe/containers/ZeebeBrokerNodeTest.java
+++ b/core/src/test/java/io/zeebe/containers/ZeebeBrokerNodeTest.java
@@ -134,11 +134,12 @@ final class ZeebeBrokerNodeTest {
     // given
     final List<Integer> expectedPorts =
         Arrays.stream(ZeebePort.values()).map(ZeebePort::getPort).collect(Collectors.toList());
+    final List<Integer> gatewayPorts =
+        Arrays.asList(ZeebePort.GATEWAY_GRPC.getPort(), ZeebePort.GATEWAY_REST.getPort());
+    expectedPorts.removeAll(gatewayPorts);
 
     // when
     final List<Integer> exposedPorts = node.getExposedPorts();
-    expectedPorts.remove((Integer) ZeebePort.GATEWAY_GRPC.getPort());
-    expectedPorts.remove((Integer) ZeebePort.GATEWAY_REST.getPort());
 
     // then
     assertThat(exposedPorts)

--- a/core/src/test/java/io/zeebe/containers/ZeebeBrokerNodeTest.java
+++ b/core/src/test/java/io/zeebe/containers/ZeebeBrokerNodeTest.java
@@ -137,7 +137,8 @@ final class ZeebeBrokerNodeTest {
 
     // when
     final List<Integer> exposedPorts = node.getExposedPorts();
-    expectedPorts.remove((Integer) ZeebePort.GATEWAY.getPort());
+    expectedPorts.remove((Integer) ZeebePort.GATEWAY_GRPC.getPort());
+    expectedPorts.remove((Integer) ZeebePort.GATEWAY_REST.getPort());
 
     // then
     assertThat(exposedPorts)

--- a/core/src/test/java/io/zeebe/containers/cluster/ZeebeClusterTest.java
+++ b/core/src/test/java/io/zeebe/containers/cluster/ZeebeClusterTest.java
@@ -82,7 +82,11 @@ final class ZeebeClusterTest {
     for (final ZeebeGatewayNode<?> gateway : cluster.getGateways().values()) {
       final Topology topology;
       try (final ZeebeClient client =
-          cluster.newClientBuilder().gatewayAddress(gateway.getExternalGatewayAddress()).build()) {
+          cluster
+              .newClientBuilder()
+              .grpcAddress(gateway.getGrpcAddress())
+              .restAddress(gateway.getRestAddress())
+              .build()) {
         topology = client.newTopologyRequest().send().join();
       }
 
@@ -154,7 +158,8 @@ final class ZeebeClusterTest {
       try (final ZeebeClient client =
           ZeebeClient.newClientBuilder()
               .usePlaintext()
-              .gatewayAddress(gateway.getExternalGatewayAddress())
+              .grpcAddress(gateway.getGrpcAddress())
+              .restAddress(gateway.getRestAddress())
               .build()) {
         final Topology topology = client.newTopologyRequest().send().join();
         assertThat(topology.getPartitionsCount())

--- a/core/src/test/java/io/zeebe/containers/examples/ClusterWithEmbeddedGatewaysExampleTest.java
+++ b/core/src/test/java/io/zeebe/containers/examples/ClusterWithEmbeddedGatewaysExampleTest.java
@@ -116,7 +116,8 @@ final class ClusterWithEmbeddedGatewaysExampleTest {
 
   private ZeebeClient newZeebeClient(final ZeebeContainer node) {
     return ZeebeClient.newClientBuilder()
-        .gatewayAddress(node.getExternalGatewayAddress())
+        .grpcAddress(node.getGrpcAddress())
+        .restAddress(node.getRestAddress())
         .usePlaintext()
         .build();
   }

--- a/core/src/test/java/io/zeebe/containers/examples/ClusterWithGatewayExampleTest.java
+++ b/core/src/test/java/io/zeebe/containers/examples/ClusterWithGatewayExampleTest.java
@@ -123,7 +123,8 @@ final class ClusterWithGatewayExampleTest {
 
   private ZeebeClient newZeebeClient(final ZeebeGatewayContainer node) {
     return ZeebeClient.newClientBuilder()
-        .gatewayAddress(node.getExternalGatewayAddress())
+        .grpcAddress(node.getGrpcAddress())
+        .restAddress(node.getRestAddress())
         .usePlaintext()
         .build();
   }

--- a/core/src/test/java/io/zeebe/containers/examples/ReusableVolumeExampleTest.java
+++ b/core/src/test/java/io/zeebe/containers/examples/ReusableVolumeExampleTest.java
@@ -23,9 +23,8 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.containers.ZeebeContainer;
 import io.zeebe.containers.ZeebeVolume;
-import java.util.concurrent.TimeUnit;
-
 import io.zeebe.containers.util.TestSupport;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;

--- a/core/src/test/java/io/zeebe/containers/examples/ReusableVolumeExampleTest.java
+++ b/core/src/test/java/io/zeebe/containers/examples/ReusableVolumeExampleTest.java
@@ -24,6 +24,8 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.containers.ZeebeContainer;
 import io.zeebe.containers.ZeebeVolume;
 import java.util.concurrent.TimeUnit;
+
+import io.zeebe.containers.util.TestSupport;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -56,7 +58,7 @@ final class ReusableVolumeExampleTest {
         Bpmn.createExecutableProcess("process").startEvent().endEvent().done();
 
     // when
-    try (final ZeebeClient client = newZeebeClient(zeebeContainer)) {
+    try (final ZeebeClient client = TestSupport.newZeebeClient(zeebeContainer)) {
       client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
     }
 
@@ -67,7 +69,7 @@ final class ReusableVolumeExampleTest {
     // create a process instance from the one we previously deployed - this would fail if we hadn't
     // previously deployed our process model
     final ProcessInstanceEvent processInstance;
-    try (final ZeebeClient client = newZeebeClient(zeebeContainer)) {
+    try (final ZeebeClient client = TestSupport.newZeebeClient(zeebeContainer)) {
       processInstance =
           client.newCreateInstanceCommand().bpmnProcessId("process").latestVersion().send().join();
     }
@@ -76,12 +78,5 @@ final class ReusableVolumeExampleTest {
     assertThat(processInstance.getProcessInstanceKey())
         .as("a process instance was successfully created")
         .isPositive();
-  }
-
-  private ZeebeClient newZeebeClient(final ZeebeContainer node) {
-    return ZeebeClient.newClientBuilder()
-        .gatewayAddress(node.getExternalGatewayAddress())
-        .usePlaintext()
-        .build();
   }
 }

--- a/core/src/test/java/io/zeebe/containers/examples/SingleNodeTest.java
+++ b/core/src/test/java/io/zeebe/containers/examples/SingleNodeTest.java
@@ -22,10 +22,9 @@ import io.camunda.zeebe.client.api.worker.JobWorker;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.containers.ZeebeContainer;
+import io.zeebe.containers.util.TestSupport;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-
-import io.zeebe.containers.util.TestSupport;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.util.Maps;
 import org.junit.jupiter.api.AutoClose;

--- a/core/src/test/java/io/zeebe/containers/examples/SingleNodeTest.java
+++ b/core/src/test/java/io/zeebe/containers/examples/SingleNodeTest.java
@@ -24,6 +24,8 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.containers.ZeebeContainer;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
+import io.zeebe.containers.util.TestSupport;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.util.Maps;
 import org.junit.jupiter.api.AutoClose;
@@ -61,7 +63,7 @@ final class SingleNodeTest {
     final ProcessInstanceResult workflowInstanceResult;
 
     // when
-    try (final ZeebeClient client = newZeebeClient(zeebeContainer)) {
+    try (final ZeebeClient client = TestSupport.newZeebeClient(zeebeContainer)) {
       try (final JobWorker ignored = createJobWorker(variables, client)) {
         deploymentEvent =
             client
@@ -98,12 +100,5 @@ final class SingleNodeTest {
             (jobClient, job) ->
                 jobClient.newCompleteCommand(job.getKey()).variables(variables).send())
         .open();
-  }
-
-  private ZeebeClient newZeebeClient(final ZeebeContainer node) {
-    return ZeebeClient.newClientBuilder()
-        .gatewayAddress(node.getExternalGatewayAddress())
-        .usePlaintext()
-        .build();
   }
 }

--- a/core/src/test/java/io/zeebe/containers/examples/archive/RestartWithExtractedDataExampleTest.java
+++ b/core/src/test/java/io/zeebe/containers/examples/archive/RestartWithExtractedDataExampleTest.java
@@ -26,6 +26,8 @@ import io.zeebe.containers.ZeebeVolume;
 import io.zeebe.containers.archive.ContainerArchive;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
+
+import io.zeebe.containers.util.TestSupport;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.LoggerFactory;
@@ -102,11 +104,7 @@ final class RestartWithExtractedDataExampleTest {
   }
 
   private void deployProcess(final ZeebeContainer container) {
-    try (final ZeebeClient client =
-        ZeebeClient.newClientBuilder()
-            .usePlaintext()
-            .gatewayAddress(container.getExternalGatewayAddress())
-            .build()) {
+    try (final ZeebeClient client = TestSupport.newZeebeClient(container)) {
       client
           .newDeployResourceCommand()
           .addProcessModel(
@@ -118,11 +116,7 @@ final class RestartWithExtractedDataExampleTest {
   }
 
   private ProcessInstanceEvent createProcessInstance(final ZeebeContainer container) {
-    try (final ZeebeClient client =
-        ZeebeClient.newClientBuilder()
-            .usePlaintext()
-            .gatewayAddress(container.getExternalGatewayAddress())
-            .build()) {
+    try (final ZeebeClient client = TestSupport.newZeebeClient(container)) {
       return client
           .newCreateInstanceCommand()
           .bpmnProcessId(PROCESS_ID)

--- a/core/src/test/java/io/zeebe/containers/examples/archive/RestartWithExtractedDataExampleTest.java
+++ b/core/src/test/java/io/zeebe/containers/examples/archive/RestartWithExtractedDataExampleTest.java
@@ -24,10 +24,9 @@ import io.zeebe.containers.ZeebeContainer;
 import io.zeebe.containers.ZeebeDefaults;
 import io.zeebe.containers.ZeebeVolume;
 import io.zeebe.containers.archive.ContainerArchive;
+import io.zeebe.containers.util.TestSupport;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
-
-import io.zeebe.containers.util.TestSupport;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.LoggerFactory;

--- a/core/src/test/java/io/zeebe/containers/examples/clock/TriggerTimerCatchEventTest.java
+++ b/core/src/test/java/io/zeebe/containers/examples/clock/TriggerTimerCatchEventTest.java
@@ -28,6 +28,8 @@ import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
+
+import io.zeebe.containers.util.TestSupport;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
@@ -77,7 +79,7 @@ final class TriggerTimerCatchEventTest {
 
     // when
     final JobHandler handler = (client, job) -> activatedJobs.add(job);
-    try (final ZeebeClient client = newZeebeClient(zeebeContainer);
+    try (final ZeebeClient client = TestSupport.newZeebeClient(zeebeContainer);
         final JobWorker ignored = newJobWorker(handler, client)) {
       client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
       client.newCreateInstanceCommand().bpmnProcessId("process").latestVersion().send().join();
@@ -97,12 +99,5 @@ final class TriggerTimerCatchEventTest {
 
   private JobWorker newJobWorker(final JobHandler handler, final ZeebeClient client) {
     return client.newWorker().jobType(JOB_TYPE).handler(handler).open();
-  }
-
-  private ZeebeClient newZeebeClient(final ZeebeContainer node) {
-    return ZeebeClient.newClientBuilder()
-        .gatewayAddress(node.getExternalGatewayAddress())
-        .usePlaintext()
-        .build();
   }
 }

--- a/core/src/test/java/io/zeebe/containers/examples/clock/TriggerTimerCatchEventTest.java
+++ b/core/src/test/java/io/zeebe/containers/examples/clock/TriggerTimerCatchEventTest.java
@@ -23,13 +23,12 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.containers.ZeebeContainer;
 import io.zeebe.containers.clock.ZeebeClock;
+import io.zeebe.containers.util.TestSupport;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
-
-import io.zeebe.containers.util.TestSupport;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;

--- a/core/src/test/java/io/zeebe/containers/examples/clock/TriggerTimerStartEventTest.java
+++ b/core/src/test/java/io/zeebe/containers/examples/clock/TriggerTimerStartEventTest.java
@@ -28,6 +28,8 @@ import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
+
+import io.zeebe.containers.util.TestSupport;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
@@ -76,7 +78,7 @@ final class TriggerTimerStartEventTest {
 
     // when
     final JobHandler handler = (client, job) -> activatedJobs.add(job);
-    try (final ZeebeClient client = newZeebeClient(zeebeContainer);
+    try (final ZeebeClient client = TestSupport.newZeebeClient(zeebeContainer);
         final JobWorker ignored = newJobWorker(handler, client)) {
       client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
       brokerTime = clock.addTime(TIME_OFFSET);
@@ -95,12 +97,5 @@ final class TriggerTimerStartEventTest {
 
   private JobWorker newJobWorker(final JobHandler handler, final ZeebeClient client) {
     return client.newWorker().jobType(JOB_TYPE).handler(handler).open();
-  }
-
-  private ZeebeClient newZeebeClient(final ZeebeContainer node) {
-    return ZeebeClient.newClientBuilder()
-        .gatewayAddress(node.getExternalGatewayAddress())
-        .usePlaintext()
-        .build();
   }
 }

--- a/core/src/test/java/io/zeebe/containers/examples/clock/TriggerTimerStartEventTest.java
+++ b/core/src/test/java/io/zeebe/containers/examples/clock/TriggerTimerStartEventTest.java
@@ -23,13 +23,12 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.containers.ZeebeContainer;
 import io.zeebe.containers.clock.ZeebeClock;
+import io.zeebe.containers.util.TestSupport;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
-
-import io.zeebe.containers.util.TestSupport;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;

--- a/core/src/test/java/io/zeebe/containers/examples/exporter/BrokerWithDebugExporterIT.java
+++ b/core/src/test/java/io/zeebe/containers/examples/exporter/BrokerWithDebugExporterIT.java
@@ -27,6 +27,8 @@ import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
+
+import io.zeebe.containers.util.TestSupport;
 import org.assertj.core.groups.Tuple;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
@@ -67,11 +69,7 @@ final class BrokerWithDebugExporterIT {
   @Test
   void shouldReadExportedRecords() {
     // given
-    try (final ZeebeClient client =
-        ZeebeClient.newClientBuilder()
-            .usePlaintext()
-            .gatewayAddress(container.getExternalGatewayAddress())
-            .build()) {
+    try (final ZeebeClient client = TestSupport.newZeebeClient(container)) {
 
       // when
       client

--- a/core/src/test/java/io/zeebe/containers/examples/exporter/BrokerWithDebugExporterIT.java
+++ b/core/src/test/java/io/zeebe/containers/examples/exporter/BrokerWithDebugExporterIT.java
@@ -23,12 +23,11 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.zeebe.containers.ZeebeContainer;
 import io.zeebe.containers.exporter.DebugReceiver;
+import io.zeebe.containers.util.TestSupport;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
-
-import io.zeebe.containers.util.TestSupport;
 import org.assertj.core.groups.Tuple;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;

--- a/core/src/test/java/io/zeebe/containers/util/TestSupport.java
+++ b/core/src/test/java/io/zeebe/containers/util/TestSupport.java
@@ -60,7 +60,8 @@ public final class TestSupport {
   public static ZeebeClient newZeebeClient(final ZeebeGatewayNode<?> gateway) {
     return ZeebeClient.newClientBuilder()
         .usePlaintext()
-        .gatewayAddress(gateway.getExternalGatewayAddress())
+        .grpcAddress(gateway.getGrpcAddress())
+        .restAddress(gateway.getRestAddress())
         .build();
   }
 

--- a/engine/src/main/java/io/zeebe/containers/engine/ZeebeClusterEngine.java
+++ b/engine/src/main/java/io/zeebe/containers/engine/ZeebeClusterEngine.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.ZeebeClientBuilder;
 import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
 import io.camunda.zeebe.process.test.api.RecordStreamSource;
+import io.zeebe.containers.ZeebeGatewayNode;
 import io.zeebe.containers.ZeebeNode;
 import io.zeebe.containers.clock.ZeebeClock;
 import io.zeebe.containers.cluster.ZeebeCluster;
@@ -77,6 +78,7 @@ final class ZeebeClusterEngine implements TestAwareContainerEngine {
     return createClient(b -> b.withJsonMapper(new ZeebeObjectMapper(customObjectMapper)));
   }
 
+  @SuppressWarnings("deprecation")
   @Override
   public String getGatewayAddress() {
     return cluster.getAvailableGateway().getExternalGatewayAddress();
@@ -114,9 +116,13 @@ final class ZeebeClusterEngine implements TestAwareContainerEngine {
   }
 
   private ZeebeClient createClient(final UnaryOperator<ZeebeClientBuilder> configurator) {
+    final ZeebeGatewayNode<?> gateway = cluster.getAvailableGateway();
     final ZeebeClientBuilder builder =
         configurator.apply(
-            ZeebeClient.newClientBuilder().usePlaintext().gatewayAddress(getGatewayAddress()));
+            ZeebeClient.newClientBuilder()
+                .usePlaintext()
+                .grpcAddress(gateway.getGrpcAddress())
+                .restAddress(gateway.getRestAddress()));
     final ZeebeClient client = builder.build();
     clients.add(client);
 

--- a/engine/src/main/java/io/zeebe/containers/engine/ZeebeContainerEngine.java
+++ b/engine/src/main/java/io/zeebe/containers/engine/ZeebeContainerEngine.java
@@ -75,6 +75,7 @@ final class ZeebeContainerEngine<
     return createClient(b -> b.withJsonMapper(new ZeebeObjectMapper(objectMapper)));
   }
 
+  @SuppressWarnings("deprecation")
   @Override
   public String getGatewayAddress() {
     return container.getExternalGatewayAddress();
@@ -114,7 +115,10 @@ final class ZeebeContainerEngine<
   private ZeebeClient createClient(final UnaryOperator<ZeebeClientBuilder> configurator) {
     final ZeebeClientBuilder builder =
         configurator.apply(
-            ZeebeClient.newClientBuilder().usePlaintext().gatewayAddress(getGatewayAddress()));
+            ZeebeClient.newClientBuilder()
+                .usePlaintext()
+                .grpcAddress(container.getGrpcAddress())
+                .restAddress(container.getRestAddress()));
     final ZeebeClient client = builder.build();
     clients.add(client);
 

--- a/engine/src/test/java/io/zeebe/containers/engine/ZeebeClusterEngineIT.java
+++ b/engine/src/test/java/io/zeebe/containers/engine/ZeebeClusterEngineIT.java
@@ -114,6 +114,7 @@ final class ZeebeClusterEngineIT {
           .succeedsWithin(Duration.ofSeconds(1));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     void shouldReturnGatewayAddress() {
       // given

--- a/engine/src/test/java/io/zeebe/containers/engine/ZeebeContainerEngineIT.java
+++ b/engine/src/test/java/io/zeebe/containers/engine/ZeebeContainerEngineIT.java
@@ -97,6 +97,7 @@ final class ZeebeContainerEngineIT {
           .succeedsWithin(Duration.ofSeconds(1));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     void shouldReturnGatewayAddress() {
       // given


### PR DESCRIPTION
## Description

This PR adds support for the REST API, introducing two new methods: `ZeebeGatewayNode#getGrpcAddress` and `ZeebeGatewayNode#getRestAddress`. It also deprecates the old `get*GatewayAddress` variants.

Similarly, there are new `ZeebePort#GATEWAY_REST` and `ZeebePort#GATEWAY_GRPC`, with `ZeebePort#GATEWAY` being deprecated.

## Related issues

closes #623 

