### PR TITLE
refactor: prepare for 8.7.0 client module migration

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,12 +1,6 @@
 <extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
   <extension>
-    <groupId>org.apache.maven.extensions</groupId>
-    <artifactId>maven-build-cache-extension</artifactId>
-    <version>1.2.0</version>
-  </extension>
-
-  <extension>
     <groupId>fr.jcgay.maven</groupId>
     <artifactId>maven-profiler</artifactId>
     <version>3.2</version>

--- a/README.md
+++ b/README.md
@@ -171,9 +171,9 @@ junit4 [here](https://www.testcontainers.org/test_framework_integration/junit_4/
 ```java
 package com.acme.zeebe;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.DeploymentEvent;
-import io.camunda.zeebe.client.api.response.ProcessInstanceResult;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.DeploymentEvent;
+import io.camunda.client.api.response.ProcessInstanceResult;
 import io.zeebe.containers.ZeebeContainer;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -189,8 +189,8 @@ public class MyFeatureTest {
   @Test
   public void shouldConnectToZeebe() {
     // given
-    final ZeebeClient client =
-      ZeebeClient.newClientBuilder()
+    final CamundaClient client =
+      CamundaClient.newClientBuilder()
         .grpcAddress(zeebeContainer.getGrpcAddress())
         .restAddress(zeebeContainer.getRestAddress())
         .usePlaintext()
@@ -228,9 +228,9 @@ extension [here](https://www.testcontainers.org/test_framework_integration/junit
 ```java
 package com.acme.zeebe;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.DeploymentEvent;
-import io.camunda.zeebe.client.api.response.ProcessInstanceResult;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.DeploymentEvent;
+import io.camunda.client.api.response.ProcessInstanceResult;
 import io.zeebe.containers.ZeebeContainer;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -248,8 +248,8 @@ public class MyFeatureTest {
   @Test
   void shouldConnectToZeebe() {
     // given
-    final ZeebeClient client =
-      ZeebeClient.newClientBuilder()
+    final CamundaClient client =
+      CamundaClient.newClientBuilder()
         .grpcAddress(zeebeContainer.getGrpcAddress())
         .restAddress(zeebeContainer.getRestAddress())
         .usePlaintext()
@@ -622,9 +622,9 @@ Here is a short example on how to set up a cluster for testing with junit5.
 ```java
 package com.acme.zeebe;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.BrokerInfo;
-import io.camunda.zeebe.client.api.response.Topology;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.BrokerInfo;
+import io.camunda.client.api.response.Topology;
 import io.zeebe.containers.cluster.ZeebeCluster;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -660,7 +660,7 @@ class ZeebeClusterWithGatewayExampleTest {
     final Topology topology;
 
     // when
-    try (final ZeebeClient client = cluster.newClientBuilder().build()) {
+    try (final CamundaClient client = cluster.newClientBuilder().build()) {
       topology = client.newTopologyRequest().send().join(5, TimeUnit.SECONDS);
     }
 
@@ -1146,8 +1146,8 @@ and waits for its completion:
 ```java
 package com.acme;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.process.test.assertions.BpmnAssert;
@@ -1176,7 +1176,7 @@ final class ExampleTest {
     final ProcessInstanceEvent processInstance;
 
     // when
-    try (final ZeebeClient client = engine.createClient()) {
+    try (final CamundaClient client = engine.createClient()) {
       client.newDeployResourceCommand().addProcessModel(processModel, "process.bpmn").send().join();
       processInstance =
         client.newCreateInstanceCommand().bpmnProcessId("process").latestVersion().send().join();

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -49,7 +49,7 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-client-java</artifactId>
+      <artifactId>camunda-client-java</artifactId>
     </dependency>
 
     <dependency>

--- a/core/src/main/java/io/zeebe/containers/ZeebeContainer.java
+++ b/core/src/main/java/io/zeebe/containers/ZeebeContainer.java
@@ -40,7 +40,7 @@ import org.testcontainers.utility.DockerImageName;
  * <p>Once started, you can build a new client for it e.g.:
  *
  * <pre>{@code
- * ZeebeClient.newClientBuilder()
+ * CamundaClient.newClientBuilder()
  *   .brokerContainerPoint(container.getExternalGatewayAddress())
  *   .usePlaintext()
  *   .build();

--- a/core/src/main/java/io/zeebe/containers/ZeebeDefaults.java
+++ b/core/src/main/java/io/zeebe/containers/ZeebeDefaults.java
@@ -15,7 +15,7 @@
  */
 package io.zeebe.containers;
 
-import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.client.CamundaClient;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 import org.testcontainers.utility.DockerImageName;
@@ -32,7 +32,7 @@ public final class ZeebeDefaults {
   private static final String DEFAULT_ZEEBE_CONTAINER_IMAGE = "camunda/zeebe";
   private static final String ZEEBE_CONTAINER_VERSION_PROPERTY = "zeebe.container.version";
   private static final String DEFAULT_ZEEBE_VERSION =
-      ZeebeClient.class.getPackage().getImplementationVersion();
+      CamundaClient.class.getPackage().getImplementationVersion();
   private static final String DEFAULT_ZEEBE_DATA_PATH = "/usr/local/zeebe/data";
   private static final String DEFAULT_ZEEBE_LOGS_PATH = "/usr/local/zeebe/logs";
   private static final String DEFAULT_ZEEBE_TMP_PATH = "/tmp";

--- a/core/src/main/java/io/zeebe/containers/ZeebeGatewayContainer.java
+++ b/core/src/main/java/io/zeebe/containers/ZeebeGatewayContainer.java
@@ -55,7 +55,7 @@ import org.testcontainers.utility.DockerImageName;
  * <p>Once started, you can build a new client for it e.g.:
  *
  * <pre>{@code
- * ZeebeClient.newClientBuilder()
+ * CamundaClient.newClientBuilder()
  *   .grpcAddress(container.getGrpcAddress())
  *   .restAddress(container.getRestAddress())
  *   .usePlaintext()

--- a/core/src/main/java/io/zeebe/containers/ZeebeGatewayNode.java
+++ b/core/src/main/java/io/zeebe/containers/ZeebeGatewayNode.java
@@ -72,7 +72,7 @@ public interface ZeebeGatewayNode<T extends GenericContainer<T> & ZeebeGatewayNo
    * <p>You can build your client like this:
    *
    * <pre>@{code
-   *   ZeebeClient.newClientBuilder()
+   *   CamundaClient.newClientBuilder()
    *     .gatewayAddress(container.getExternalGatewayAddress())
    *     .usePlaintext()
    *     .build();
@@ -93,7 +93,7 @@ public interface ZeebeGatewayNode<T extends GenericContainer<T> & ZeebeGatewayNo
    * <p>You can build your client like this:
    *
    * <pre>@{code
-   *   ZeebeClient.newClientBuilder()
+   *   CamundaClient.newClientBuilder()
    *     .gatewayAddress(container.getInternalGatewayAddress())
    *     .usePlaintext()
    *     .build();
@@ -115,7 +115,7 @@ public interface ZeebeGatewayNode<T extends GenericContainer<T> & ZeebeGatewayNo
    * <p>You can build your client like this:
    *
    * <pre>@{code
-   *   ZeebeClient.newClientBuilder()
+   *   CamundaClient.newClientBuilder()
    *     .restAddress(container.getInternalRestUrl())
    *     .usePlaintext()
    *     .build();
@@ -136,7 +136,7 @@ public interface ZeebeGatewayNode<T extends GenericContainer<T> & ZeebeGatewayNo
    * <p>You can build your client like this:
    *
    * <pre>@{code
-   *   ZeebeClient.newClientBuilder()
+   *   CamundaClient.newClientBuilder()
    *     .restAddress(container.getInternalRestUrl("https"))
    *     .build();
    * }</pre>
@@ -157,7 +157,7 @@ public interface ZeebeGatewayNode<T extends GenericContainer<T> & ZeebeGatewayNo
    * <p>You can build your client like this:
    *
    * <pre>@{code
-   *   ZeebeClient.newClientBuilder()
+   *   CamundaClient.newClientBuilder()
    *     .restAddress(container.getRestAddress())
    *     .usePlaintext()
    *     .build();
@@ -179,7 +179,7 @@ public interface ZeebeGatewayNode<T extends GenericContainer<T> & ZeebeGatewayNo
    * <p>You can build your client like this:
    *
    * <pre>@{code
-   *   ZeebeClient.newClientBuilder()
+   *   CamundaClient.newClientBuilder()
    *     .restAddress(container.getExternalRestAddress("https"))
    *     .build();
    * }</pre>
@@ -199,7 +199,7 @@ public interface ZeebeGatewayNode<T extends GenericContainer<T> & ZeebeGatewayNo
    * <p>You can build your client like this:
    *
    * <pre>@{code
-   *   ZeebeClient.newClientBuilder()
+   *   CamundaClient.newClientBuilder()
    *     .grpcAddress(container.getInternalGrpcAddress())
    *     .usePlaintext()
    *     .build();
@@ -220,7 +220,7 @@ public interface ZeebeGatewayNode<T extends GenericContainer<T> & ZeebeGatewayNo
    * <p>You can build your client like this:
    *
    * <pre>@{code
-   *   ZeebeClient.newClientBuilder()
+   *   CamundaClient.newClientBuilder()
    *     .grpcAddress(container.getInternalGrpcAddress("https"))
    *     .build();
    * }</pre>
@@ -241,7 +241,7 @@ public interface ZeebeGatewayNode<T extends GenericContainer<T> & ZeebeGatewayNo
    * <p>You can build your client like this:
    *
    * <pre>@{code
-   *   ZeebeClient.newClientBuilder()
+   *   CamundaClient.newClientBuilder()
    *     .grpcAddress(container.getGrpcAddress())
    *     .usePlaintext()
    *     .build();
@@ -263,7 +263,7 @@ public interface ZeebeGatewayNode<T extends GenericContainer<T> & ZeebeGatewayNo
    * <p>You can build your client like this:
    *
    * <pre>@{code
-   *   ZeebeClient.newClientBuilder()
+   *   CamundaClient.newClientBuilder()
    *     .grpcAddress(container.getGrpcAddress("https"))
    *     .build();
    * }</pre>

--- a/core/src/main/java/io/zeebe/containers/ZeebeHostData.java
+++ b/core/src/main/java/io/zeebe/containers/ZeebeHostData.java
@@ -47,6 +47,7 @@ import org.testcontainers.containers.GenericContainer;
 @API(status = Status.EXPERIMENTAL)
 public class ZeebeHostData implements ZeebeData {
   private final String hostPath;
+  private final String mountPath;
 
   /**
    * Creates a new {@link ZeebeHostData} which points to the given host path.
@@ -54,12 +55,21 @@ public class ZeebeHostData implements ZeebeData {
    * @param hostPath the path where the data will be stored on the host
    */
   public ZeebeHostData(final String hostPath) {
+    this(hostPath, ZeebeDefaults.getInstance().getDefaultDataPath());
+  }
+
+  /**
+   * Creates a new {@link ZeebeHostData} which points to the given host path.
+   *
+   * @param hostPath the path where the data will be stored on the host
+   */
+  public ZeebeHostData(final String hostPath, final String mountPath) {
     this.hostPath = hostPath;
+    this.mountPath = mountPath;
   }
 
   @Override
   public <T extends GenericContainer<T> & ZeebeBrokerNode<T>> void attach(final T container) {
-    final String containerPath = ZeebeDefaults.getInstance().getDefaultDataPath();
-    container.withFileSystemBind(hostPath, containerPath, BindMode.READ_WRITE);
+    container.withFileSystemBind(hostPath, mountPath, BindMode.READ_WRITE);
   }
 }

--- a/core/src/main/java/io/zeebe/containers/ZeebeTopologyWaitStrategy.java
+++ b/core/src/main/java/io/zeebe/containers/ZeebeTopologyWaitStrategy.java
@@ -104,7 +104,7 @@ public class ZeebeTopologyWaitStrategy extends AbstractWaitStrategy {
    */
   public ZeebeTopologyWaitStrategy(
       final int brokersCount, final int replicationFactor, final int partitionsCount) {
-    this(brokersCount, replicationFactor, partitionsCount, ZeebePort.GATEWAY_REST.getPort());
+    this(brokersCount, replicationFactor, partitionsCount, ZeebePort.GATEWAY_GRPC.getPort());
   }
 
   /**

--- a/core/src/main/java/io/zeebe/containers/ZeebeTopologyWaitStrategy.java
+++ b/core/src/main/java/io/zeebe/containers/ZeebeTopologyWaitStrategy.java
@@ -17,11 +17,11 @@ package io.zeebe.containers;
 
 import static org.rnorth.ducttape.unreliables.Unreliables.retryUntilTrue;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.ZeebeClientBuilder;
-import io.camunda.zeebe.client.api.response.BrokerInfo;
-import io.camunda.zeebe.client.api.response.PartitionInfo;
-import io.camunda.zeebe.client.api.response.Topology;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.CamundaClientBuilder;
+import io.camunda.client.api.response.BrokerInfo;
+import io.camunda.client.api.response.PartitionInfo;
+import io.camunda.client.api.response.Topology;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -64,7 +64,7 @@ public class ZeebeTopologyWaitStrategy extends AbstractWaitStrategy {
   private int replicationFactor;
   private int partitionsCount;
   private int gatewayPort;
-  private Supplier<ZeebeClientBuilder> clientBuilderProvider;
+  private Supplier<CamundaClientBuilder> clientBuilderProvider;
 
   /**
    * Creates a new topology wait strategy for a single broker/replica, which is the Zeebe default as
@@ -104,7 +104,7 @@ public class ZeebeTopologyWaitStrategy extends AbstractWaitStrategy {
    */
   public ZeebeTopologyWaitStrategy(
       final int brokersCount, final int replicationFactor, final int partitionsCount) {
-    this(brokersCount, replicationFactor, partitionsCount, ZeebePort.GATEWAY_GRPC.getPort());
+    this(brokersCount, replicationFactor, partitionsCount, ZeebePort.GATEWAY_REST.getPort());
   }
 
   /**
@@ -127,7 +127,7 @@ public class ZeebeTopologyWaitStrategy extends AbstractWaitStrategy {
     this.partitionsCount = partitionsCount;
     this.gatewayPort = gatewayPort;
 
-    this.clientBuilderProvider = () -> ZeebeClient.newClientBuilder().usePlaintext();
+    this.clientBuilderProvider = () -> CamundaClient.newClientBuilder().usePlaintext();
   }
 
   /**
@@ -186,7 +186,7 @@ public class ZeebeTopologyWaitStrategy extends AbstractWaitStrategy {
    * based on the given target. This is mostly useful if you wish to enable TLS/SSL on your gateway,
    * at which point you can configure whatever you want.
    *
-   * <p>Caveat: as the default provider applies {@link ZeebeClientBuilder#usePlaintext()}, if you
+   * <p>Caveat: as the default provider applies {@link CamundaClientBuilder#usePlaintext()}, if you
    * still wish to use plaintext, make sure to call it as well in your custom provider.
    *
    * @param clientBuilderProvider the new client builder provider
@@ -194,7 +194,7 @@ public class ZeebeTopologyWaitStrategy extends AbstractWaitStrategy {
    */
   @API(status = Status.EXPERIMENTAL)
   public ZeebeTopologyWaitStrategy forBuilder(
-      final Supplier<ZeebeClientBuilder> clientBuilderProvider) {
+      final Supplier<CamundaClientBuilder> clientBuilderProvider) {
     this.clientBuilderProvider = clientBuilderProvider;
     return this;
   }
@@ -203,7 +203,7 @@ public class ZeebeTopologyWaitStrategy extends AbstractWaitStrategy {
   protected void waitUntilReady() {
     final TopologyHolder latestTopology = new TopologyHolder();
 
-    try (final ZeebeClient client = newZeebeClient(waitStrategyTarget)) {
+    try (final CamundaClient client = newZeebeClient(waitStrategyTarget)) {
       final String containerName = waitStrategyTarget.getContainerInfo().getName();
       LOGGER.info(
           "{}: Waiting for {} for topology to have at least {} brokers, {} partitions with "
@@ -233,7 +233,7 @@ public class ZeebeTopologyWaitStrategy extends AbstractWaitStrategy {
     }
   }
 
-  private ZeebeClient newZeebeClient(final WaitStrategyTarget waitStrategyTarget) {
+  private CamundaClient newZeebeClient(final WaitStrategyTarget waitStrategyTarget) {
     //noinspection HttpUrlsUsage
     final URI gatewayAddress =
         URI.create(
@@ -317,7 +317,7 @@ public class ZeebeTopologyWaitStrategy extends AbstractWaitStrategy {
     return partitions;
   }
 
-  private Topology getTopology(final ZeebeClient client) {
+  private Topology getTopology(final CamundaClient client) {
     return client
         .newTopologyRequest()
         .send()

--- a/core/src/main/java/io/zeebe/containers/cluster/ZeebeCluster.java
+++ b/core/src/main/java/io/zeebe/containers/cluster/ZeebeCluster.java
@@ -15,8 +15,8 @@
  */
 package io.zeebe.containers.cluster;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.ZeebeClientBuilder;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.CamundaClientBuilder;
 import io.zeebe.containers.ZeebeBrokerNode;
 import io.zeebe.containers.ZeebeGatewayNode;
 import io.zeebe.containers.ZeebeNode;
@@ -78,7 +78,7 @@ import org.testcontainers.lifecycle.Startables;
  *
  *     // when
  *     final Topology topology;
- *     try (final ZeebeClient client = cluster.newClientBuilder().build()) {
+ *     try (final CamundaClient client = cluster.newClientBuilder().build()) {
  *       topology = c.newTopologyRequest().send().join();
  *     }
  *
@@ -230,10 +230,10 @@ public class ZeebeCluster implements Startable {
    * @return a new client builder with the gateway and transport security pre-configured
    * @throws NoSuchElementException if there are no started gateways
    */
-  public ZeebeClientBuilder newClientBuilder() {
+  public CamundaClientBuilder newClientBuilder() {
     final ZeebeGatewayNode<?> gateway = getAvailableGateway();
 
-    return ZeebeClient.newClientBuilder()
+    return CamundaClient.newClientBuilder()
         .grpcAddress(gateway.getGrpcAddress())
         .restAddress(gateway.getRestAddress())
         .usePlaintext();

--- a/core/src/test/java/io/zeebe/containers/ZeebeBrokerNodeTest.java
+++ b/core/src/test/java/io/zeebe/containers/ZeebeBrokerNodeTest.java
@@ -18,9 +18,9 @@ package io.zeebe.containers;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.condition.OS.LINUX;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.DeploymentEvent;
-import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.DeploymentEvent;
+import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.containers.util.TestSupport;
@@ -168,7 +168,7 @@ final class ZeebeBrokerNodeTest {
       broker.start();
       gateway.start();
 
-      try (final ZeebeClient client = TestSupport.newZeebeClient(gateway)) {
+      try (final CamundaClient client = TestSupport.newZeebeClient(gateway)) {
         // deploy a new process, which we can use on restart to assert that the data was correctly
         // reused
         final DeploymentEvent deployment = deploySampleProcess(client);
@@ -189,11 +189,11 @@ final class ZeebeBrokerNodeTest {
     }
   }
 
-  private ProcessInstanceEvent createSampleProcessInstance(final ZeebeClient client) {
+  private ProcessInstanceEvent createSampleProcessInstance(final CamundaClient client) {
     return client.newCreateInstanceCommand().bpmnProcessId("process").latestVersion().send().join();
   }
 
-  private DeploymentEvent deploySampleProcess(final ZeebeClient client) {
+  private DeploymentEvent deploySampleProcess(final CamundaClient client) {
     final BpmnModelInstance sampleProcess =
         Bpmn.createExecutableProcess("process").startEvent().endEvent().done();
     return client
@@ -203,7 +203,7 @@ final class ZeebeBrokerNodeTest {
         .join();
   }
 
-  private void awaitUntilTopologyIsComplete(final ZeebeClient client) {
+  private void awaitUntilTopologyIsComplete(final CamundaClient client) {
     Awaitility.await("until topology is complete")
         .atMost(Duration.ofSeconds(30))
         .untilAsserted(

--- a/core/src/test/java/io/zeebe/containers/ZeebeBrokerNodeTest.java
+++ b/core/src/test/java/io/zeebe/containers/ZeebeBrokerNodeTest.java
@@ -35,7 +35,6 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.awaitility.Awaitility;

--- a/core/src/test/java/io/zeebe/containers/ZeebeContainerTest.java
+++ b/core/src/test/java/io/zeebe/containers/ZeebeContainerTest.java
@@ -15,8 +15,8 @@
  */
 package io.zeebe.containers;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.Topology;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.Topology;
 import io.zeebe.containers.util.TestSupport;
 import java.util.concurrent.TimeUnit;
 import org.assertj.core.api.Assertions;
@@ -36,7 +36,7 @@ final class ZeebeContainerTest {
     final Topology topology;
 
     // when
-    try (final ZeebeClient client = TestSupport.newZeebeClient(zeebeContainer)) {
+    try (final CamundaClient client = TestSupport.newZeebeClient(zeebeContainer)) {
       topology = client.newTopologyRequest().send().join(5, TimeUnit.SECONDS);
     }
 

--- a/core/src/test/java/io/zeebe/containers/ZeebeGatewayContainerTest.java
+++ b/core/src/test/java/io/zeebe/containers/ZeebeGatewayContainerTest.java
@@ -15,9 +15,9 @@
  */
 package io.zeebe.containers;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.BrokerInfo;
-import io.camunda.zeebe.client.api.response.Topology;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.BrokerInfo;
+import io.camunda.client.api.response.Topology;
 import io.zeebe.containers.util.TestSupport;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -54,7 +54,7 @@ final class ZeebeGatewayContainerTest {
     final Topology topology;
 
     // when
-    try (final ZeebeClient client = TestSupport.newZeebeClient(gatewayContainer)) {
+    try (final CamundaClient client = TestSupport.newZeebeClient(gatewayContainer)) {
       topology = client.newTopologyRequest().send().join(5, TimeUnit.SECONDS);
     }
 

--- a/core/src/test/java/io/zeebe/containers/ZeebeHostDataTest.java
+++ b/core/src/test/java/io/zeebe/containers/ZeebeHostDataTest.java
@@ -23,6 +23,9 @@ import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.command.InspectContainerResponse.Mount;
 import io.zeebe.containers.util.TestSupport;
 import io.zeebe.containers.util.TestcontainersSupport.DisabledIfTestcontainersCloud;
+
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
@@ -34,19 +37,33 @@ import org.testcontainers.DockerClientFactory;
 final class ZeebeHostDataTest {
   @SuppressWarnings("resource")
   @Test
-  void shouldAttachToZeebeContainer(final @TempDir Path dataDir) {
+  void shouldAttachToZeebeContainer(final @TempDir Path tmpDir) throws IOException {
     // given
+    // configure the broker to use the same UID and GID as our current user so we can remove the
+    // temporary directory at the end. Note that this is only necessary when not running the tests
+    // as root
     final DockerClient client = DockerClientFactory.lazyClient();
     final String runAsUser = TestSupport.getRunAsUser();
+    final Path dataDir = tmpDir.resolve("data");
+    Files.createDirectories(dataDir);
+
+    // create logs directory to avoid errors since we'll be running with a different user than the usual "camunda:root"
+    Files.createDirectories(tmpDir.resolve("logs"));
 
     // when
     final InspectContainerResponse response;
     try (final ZeebeBrokerContainer container = new ZeebeBrokerContainer()) {
-      final ZeebeHostData data = new ZeebeHostData(dataDir.toString());
+      final ZeebeHostData data = new ZeebeHostData(dataDir.toAbsolutePath().toString());
+      final ZeebeHostData logs =
+          new ZeebeHostData(
+              tmpDir.resolve("logs").toAbsolutePath().toString(),
+              ZeebeDefaults.getInstance().getDefaultLogsPath());
+
       // configure the broker to use the same UID and GID as our current user, so we can remove the
       // temporary directory at the end
       container
           .withZeebeData(data)
+          .withZeebeData(logs)
           .self()
           .withCreateContainerCmdModifier(cmd -> cmd.withUser(runAsUser));
       container.start();

--- a/core/src/test/java/io/zeebe/containers/ZeebeHostDataTest.java
+++ b/core/src/test/java/io/zeebe/containers/ZeebeHostDataTest.java
@@ -23,7 +23,6 @@ import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.command.InspectContainerResponse.Mount;
 import io.zeebe.containers.util.TestSupport;
 import io.zeebe.containers.util.TestcontainersSupport.DisabledIfTestcontainersCloud;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -47,7 +46,8 @@ final class ZeebeHostDataTest {
     final Path dataDir = tmpDir.resolve("data");
     Files.createDirectories(dataDir);
 
-    // create logs directory to avoid errors since we'll be running with a different user than the usual "camunda:root"
+    // create logs directory to avoid errors since we'll be running with a different user than the
+    // usual "camunda:root"
     Files.createDirectories(tmpDir.resolve("logs"));
 
     // when

--- a/core/src/test/java/io/zeebe/containers/ZeebeTopologyWaitStrategyTest.java
+++ b/core/src/test/java/io/zeebe/containers/ZeebeTopologyWaitStrategyTest.java
@@ -16,12 +16,12 @@
 package io.zeebe.containers;
 
 import com.github.dockerjava.api.command.InspectContainerResponse;
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.ZeebeClientBuilder;
-import io.camunda.zeebe.client.api.command.TopologyRequestStep1;
-import io.camunda.zeebe.client.api.response.Topology;
-import io.camunda.zeebe.client.impl.ZeebeClientFutureImpl;
-import io.camunda.zeebe.client.impl.response.TopologyImpl;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.CamundaClientBuilder;
+import io.camunda.client.api.command.TopologyRequestStep1;
+import io.camunda.client.api.response.Topology;
+import io.camunda.client.impl.CamundaClientFutureImpl;
+import io.camunda.client.impl.response.TopologyImpl;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BrokerInfo;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.Partition;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.Partition.PartitionBrokerRole;
@@ -65,8 +65,8 @@ final class ZeebeTopologyWaitStrategyTest {
   private static final int PARTITIONS_COUNT = 3;
   private static final int REPLICATION_FACTOR = 3;
 
-  @Mock ZeebeClient client;
-  @Mock ZeebeClientBuilder builder;
+  @Mock CamundaClient client;
+  @Mock CamundaClientBuilder builder;
   @Mock TopologyRequestStep1 topologyRequest;
 
   @BeforeEach
@@ -80,10 +80,10 @@ final class ZeebeTopologyWaitStrategyTest {
   @Test
   void shouldWaitUntilACompleteTopologyResponse() {
     // given
-    final ZeebeClientFutureImpl<Topology, TopologyResponse> incompleteTopologyResponse =
+    final CamundaClientFutureImpl<Topology, TopologyResponse> incompleteTopologyResponse =
         newTopologyResponse(
             newTopology(BROKERS_COUNT - 1, PARTITIONS_COUNT - 1, DEFAULT_PARTITIONER));
-    final ZeebeClientFutureImpl<Topology, TopologyResponse> completeTopologyResponse =
+    final CamundaClientFutureImpl<Topology, TopologyResponse> completeTopologyResponse =
         newTopologyResponse(newCompleteTopology());
     final WaitStrategyTarget target = new ReachableTarget(1);
     final ZeebeTopologyWaitStrategy strategy = newCompleteWaitStrategy();
@@ -102,7 +102,7 @@ final class ZeebeTopologyWaitStrategyTest {
 
   @Test
   void shouldUseCustomGatewayPort() {
-    final ZeebeClientFutureImpl<Topology, TopologyResponse> topologyResponse =
+    final CamundaClientFutureImpl<Topology, TopologyResponse> topologyResponse =
         newTopologyResponse(newCompleteTopology());
     final ReachableTarget target = new ReachableTarget(1);
     final ZeebeTopologyWaitStrategy strategy = newCompleteWaitStrategy().forGatewayPort(2);
@@ -121,7 +121,7 @@ final class ZeebeTopologyWaitStrategyTest {
 
   @Test
   void shouldUseCorrectGatewayAddress() {
-    final ZeebeClientFutureImpl<Topology, TopologyResponse> topologyResponse =
+    final CamundaClientFutureImpl<Topology, TopologyResponse> topologyResponse =
         newTopologyResponse(newCompleteTopology());
     final ReachableTarget target = new ReachableTarget(1);
     final ZeebeTopologyWaitStrategy strategy = newCompleteWaitStrategy();
@@ -145,7 +145,7 @@ final class ZeebeTopologyWaitStrategyTest {
       final String testName,
       final TopologyResponse topology,
       final ZeebeTopologyWaitStrategy strategy) {
-    final ZeebeClientFutureImpl<Topology, TopologyResponse> topologyResponse =
+    final CamundaClientFutureImpl<Topology, TopologyResponse> topologyResponse =
         newTopologyResponse(topology);
     final ReachableTarget target = new ReachableTarget(1);
 
@@ -160,10 +160,10 @@ final class ZeebeTopologyWaitStrategyTest {
     Mockito.verify(topologyRequest, Mockito.atLeastOnce()).send();
   }
 
-  private ZeebeClientFutureImpl<Topology, TopologyResponse> newTopologyResponse(
+  private CamundaClientFutureImpl<Topology, TopologyResponse> newTopologyResponse(
       final TopologyResponse topology) {
-    final ZeebeClientFutureImpl<Topology, TopologyResponse> response =
-        new ZeebeClientFutureImpl<>(TopologyImpl::new);
+    final CamundaClientFutureImpl<Topology, TopologyResponse> response =
+        new CamundaClientFutureImpl<>(TopologyImpl::new);
     response.onNext(topology);
 
     return response;

--- a/core/src/test/java/io/zeebe/containers/cluster/ZeebeClusterTest.java
+++ b/core/src/test/java/io/zeebe/containers/cluster/ZeebeClusterTest.java
@@ -17,8 +17,8 @@ package io.zeebe.containers.cluster;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.Topology;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.Topology;
 import io.zeebe.containers.ZeebeGatewayNode;
 import io.zeebe.containers.util.TopologyAssert;
 import org.junit.jupiter.api.AutoClose;
@@ -47,7 +47,7 @@ final class ZeebeClusterTest {
 
     // then
     final Topology topology;
-    try (final ZeebeClient client = cluster.newClientBuilder().build()) {
+    try (final CamundaClient client = cluster.newClientBuilder().build()) {
       topology = client.newTopologyRequest().send().join();
     }
 
@@ -81,7 +81,7 @@ final class ZeebeClusterTest {
     // then
     for (final ZeebeGatewayNode<?> gateway : cluster.getGateways().values()) {
       final Topology topology;
-      try (final ZeebeClient client =
+      try (final CamundaClient client =
           cluster
               .newClientBuilder()
               .grpcAddress(gateway.getGrpcAddress())
@@ -121,7 +121,7 @@ final class ZeebeClusterTest {
 
     // then
     final Topology topology;
-    try (final ZeebeClient client = cluster.newClientBuilder().build()) {
+    try (final CamundaClient client = cluster.newClientBuilder().build()) {
       topology = client.newTopologyRequest().send().join();
     }
 
@@ -155,8 +155,8 @@ final class ZeebeClusterTest {
 
     // then
     for (final ZeebeGatewayNode<?> gateway : cluster.getGateways().values()) {
-      try (final ZeebeClient client =
-          ZeebeClient.newClientBuilder()
+      try (final CamundaClient client =
+          CamundaClient.newClientBuilder()
               .usePlaintext()
               .grpcAddress(gateway.getGrpcAddress())
               .restAddress(gateway.getRestAddress())

--- a/core/src/test/java/io/zeebe/containers/examples/ClusterWithEmbeddedGatewaysExampleTest.java
+++ b/core/src/test/java/io/zeebe/containers/examples/ClusterWithEmbeddedGatewaysExampleTest.java
@@ -15,9 +15,9 @@
  */
 package io.zeebe.containers.examples;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.BrokerInfo;
-import io.camunda.zeebe.client.api.response.Topology;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.BrokerInfo;
+import io.camunda.client.api.response.Topology;
 import io.zeebe.containers.ZeebeBrokerNode;
 import io.zeebe.containers.ZeebeContainer;
 import io.zeebe.containers.ZeebeTopologyWaitStrategy;
@@ -67,7 +67,7 @@ final class ClusterWithEmbeddedGatewaysExampleTest {
 
     // when
     for (final ZeebeContainer gateway : containers) {
-      try (final ZeebeClient client = newZeebeClient(gateway)) {
+      try (final CamundaClient client = newZeebeClient(gateway)) {
         // then
         final Topology topology = client.newTopologyRequest().send().join(5, TimeUnit.SECONDS);
         final List<BrokerInfo> brokers = topology.getBrokers();
@@ -114,8 +114,8 @@ final class ClusterWithEmbeddedGatewaysExampleTest {
         .withEnv("ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS", initialContactPoints);
   }
 
-  private ZeebeClient newZeebeClient(final ZeebeContainer node) {
-    return ZeebeClient.newClientBuilder()
+  private CamundaClient newZeebeClient(final ZeebeContainer node) {
+    return CamundaClient.newClientBuilder()
         .grpcAddress(node.getGrpcAddress())
         .restAddress(node.getRestAddress())
         .usePlaintext()

--- a/core/src/test/java/io/zeebe/containers/examples/ClusterWithGatewayExampleTest.java
+++ b/core/src/test/java/io/zeebe/containers/examples/ClusterWithGatewayExampleTest.java
@@ -15,9 +15,9 @@
  */
 package io.zeebe.containers.examples;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.BrokerInfo;
-import io.camunda.zeebe.client.api.response.Topology;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.BrokerInfo;
+import io.camunda.client.api.response.Topology;
 import io.zeebe.containers.ZeebeBrokerContainer;
 import io.zeebe.containers.ZeebeBrokerNode;
 import io.zeebe.containers.ZeebeGatewayContainer;
@@ -78,7 +78,7 @@ final class ClusterWithGatewayExampleTest {
 
     // when
     final Topology topology;
-    try (final ZeebeClient client = newZeebeClient(gatewayContainer)) {
+    try (final CamundaClient client = newZeebeClient(gatewayContainer)) {
       topology = client.newTopologyRequest().send().join(5, TimeUnit.SECONDS);
     }
 
@@ -121,8 +121,8 @@ final class ClusterWithGatewayExampleTest {
         .withEnv("ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS", initialContactPoints);
   }
 
-  private ZeebeClient newZeebeClient(final ZeebeGatewayContainer node) {
-    return ZeebeClient.newClientBuilder()
+  private CamundaClient newZeebeClient(final ZeebeGatewayContainer node) {
+    return CamundaClient.newClientBuilder()
         .grpcAddress(node.getGrpcAddress())
         .restAddress(node.getRestAddress())
         .usePlaintext()

--- a/core/src/test/java/io/zeebe/containers/examples/ReusableVolumeExampleTest.java
+++ b/core/src/test/java/io/zeebe/containers/examples/ReusableVolumeExampleTest.java
@@ -17,8 +17,8 @@ package io.zeebe.containers.examples;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.containers.ZeebeContainer;
@@ -57,7 +57,7 @@ final class ReusableVolumeExampleTest {
         Bpmn.createExecutableProcess("process").startEvent().endEvent().done();
 
     // when
-    try (final ZeebeClient client = TestSupport.newZeebeClient(zeebeContainer)) {
+    try (final CamundaClient client = TestSupport.newZeebeClient(zeebeContainer)) {
       client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
     }
 
@@ -68,7 +68,7 @@ final class ReusableVolumeExampleTest {
     // create a process instance from the one we previously deployed - this would fail if we hadn't
     // previously deployed our process model
     final ProcessInstanceEvent processInstance;
-    try (final ZeebeClient client = TestSupport.newZeebeClient(zeebeContainer)) {
+    try (final CamundaClient client = TestSupport.newZeebeClient(zeebeContainer)) {
       processInstance =
           client.newCreateInstanceCommand().bpmnProcessId("process").latestVersion().send().join();
     }

--- a/core/src/test/java/io/zeebe/containers/examples/SingleNodeTest.java
+++ b/core/src/test/java/io/zeebe/containers/examples/SingleNodeTest.java
@@ -15,10 +15,10 @@
  */
 package io.zeebe.containers.examples;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.DeploymentEvent;
-import io.camunda.zeebe.client.api.response.ProcessInstanceResult;
-import io.camunda.zeebe.client.api.worker.JobWorker;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.DeploymentEvent;
+import io.camunda.client.api.response.ProcessInstanceResult;
+import io.camunda.client.api.worker.JobWorker;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.containers.ZeebeContainer;
@@ -62,7 +62,7 @@ final class SingleNodeTest {
     final ProcessInstanceResult workflowInstanceResult;
 
     // when
-    try (final ZeebeClient client = TestSupport.newZeebeClient(zeebeContainer)) {
+    try (final CamundaClient client = TestSupport.newZeebeClient(zeebeContainer)) {
       try (final JobWorker ignored = createJobWorker(variables, client)) {
         deploymentEvent =
             client
@@ -91,7 +91,7 @@ final class SingleNodeTest {
   }
 
   private JobWorker createJobWorker(
-      final Map<String, Integer> variables, final ZeebeClient client) {
+      final Map<String, Integer> variables, final CamundaClient client) {
     return client
         .newWorker()
         .jobType("task")

--- a/core/src/test/java/io/zeebe/containers/examples/archive/RestartWithExtractedDataExampleTest.java
+++ b/core/src/test/java/io/zeebe/containers/examples/archive/RestartWithExtractedDataExampleTest.java
@@ -17,8 +17,8 @@ package io.zeebe.containers.examples.archive;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.zeebe.containers.ZeebeContainer;
 import io.zeebe.containers.ZeebeDefaults;
@@ -103,7 +103,7 @@ final class RestartWithExtractedDataExampleTest {
   }
 
   private void deployProcess(final ZeebeContainer container) {
-    try (final ZeebeClient client = TestSupport.newZeebeClient(container)) {
+    try (final CamundaClient client = TestSupport.newZeebeClient(container)) {
       client
           .newDeployResourceCommand()
           .addProcessModel(
@@ -115,7 +115,7 @@ final class RestartWithExtractedDataExampleTest {
   }
 
   private ProcessInstanceEvent createProcessInstance(final ZeebeContainer container) {
-    try (final ZeebeClient client = TestSupport.newZeebeClient(container)) {
+    try (final CamundaClient client = TestSupport.newZeebeClient(container)) {
       return client
           .newCreateInstanceCommand()
           .bpmnProcessId(PROCESS_ID)

--- a/core/src/test/java/io/zeebe/containers/examples/clock/TriggerTimerCatchEventTest.java
+++ b/core/src/test/java/io/zeebe/containers/examples/clock/TriggerTimerCatchEventTest.java
@@ -15,10 +15,10 @@
  */
 package io.zeebe.containers.examples.clock;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.ActivatedJob;
-import io.camunda.zeebe.client.api.worker.JobHandler;
-import io.camunda.zeebe.client.api.worker.JobWorker;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.worker.JobHandler;
+import io.camunda.client.api.worker.JobWorker;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.containers.ZeebeContainer;
@@ -78,7 +78,7 @@ final class TriggerTimerCatchEventTest {
 
     // when
     final JobHandler handler = (client, job) -> activatedJobs.add(job);
-    try (final ZeebeClient client = TestSupport.newZeebeClient(zeebeContainer);
+    try (final CamundaClient client = TestSupport.newZeebeClient(zeebeContainer);
         final JobWorker ignored = newJobWorker(handler, client)) {
       client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
       client.newCreateInstanceCommand().bpmnProcessId("process").latestVersion().send().join();
@@ -96,7 +96,7 @@ final class TriggerTimerCatchEventTest {
         .isAfterOrEqualTo(TIMER_DATE);
   }
 
-  private JobWorker newJobWorker(final JobHandler handler, final ZeebeClient client) {
+  private JobWorker newJobWorker(final JobHandler handler, final CamundaClient client) {
     return client.newWorker().jobType(JOB_TYPE).handler(handler).open();
   }
 }

--- a/core/src/test/java/io/zeebe/containers/examples/clock/TriggerTimerStartEventTest.java
+++ b/core/src/test/java/io/zeebe/containers/examples/clock/TriggerTimerStartEventTest.java
@@ -15,10 +15,10 @@
  */
 package io.zeebe.containers.examples.clock;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.ActivatedJob;
-import io.camunda.zeebe.client.api.worker.JobHandler;
-import io.camunda.zeebe.client.api.worker.JobWorker;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.worker.JobHandler;
+import io.camunda.client.api.worker.JobWorker;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.zeebe.containers.ZeebeContainer;
@@ -77,7 +77,7 @@ final class TriggerTimerStartEventTest {
 
     // when
     final JobHandler handler = (client, job) -> activatedJobs.add(job);
-    try (final ZeebeClient client = TestSupport.newZeebeClient(zeebeContainer);
+    try (final CamundaClient client = TestSupport.newZeebeClient(zeebeContainer);
         final JobWorker ignored = newJobWorker(handler, client)) {
       client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
       brokerTime = clock.addTime(TIME_OFFSET);
@@ -94,7 +94,7 @@ final class TriggerTimerStartEventTest {
         .isAfterOrEqualTo(TIMER_DATE);
   }
 
-  private JobWorker newJobWorker(final JobHandler handler, final ZeebeClient client) {
+  private JobWorker newJobWorker(final JobHandler handler, final CamundaClient client) {
     return client.newWorker().jobType(JOB_TYPE).handler(handler).open();
   }
 }

--- a/core/src/test/java/io/zeebe/containers/examples/cluster/ZeebeClusterSingleNodeExampleTest.java
+++ b/core/src/test/java/io/zeebe/containers/examples/cluster/ZeebeClusterSingleNodeExampleTest.java
@@ -15,9 +15,9 @@
  */
 package io.zeebe.containers.examples.cluster;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.BrokerInfo;
-import io.camunda.zeebe.client.api.response.Topology;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.BrokerInfo;
+import io.camunda.client.api.response.Topology;
 import io.zeebe.containers.cluster.ZeebeCluster;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -60,7 +60,7 @@ final class ZeebeClusterSingleNodeExampleTest {
     final Topology topology;
 
     // when
-    try (final ZeebeClient client = cluster.newClientBuilder().build()) {
+    try (final CamundaClient client = cluster.newClientBuilder().build()) {
       topology = client.newTopologyRequest().send().join(5, TimeUnit.SECONDS);
     }
 

--- a/core/src/test/java/io/zeebe/containers/examples/cluster/ZeebeClusterWithEmbeddedGatewaysExampleTest.java
+++ b/core/src/test/java/io/zeebe/containers/examples/cluster/ZeebeClusterWithEmbeddedGatewaysExampleTest.java
@@ -15,9 +15,9 @@
  */
 package io.zeebe.containers.examples.cluster;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.BrokerInfo;
-import io.camunda.zeebe.client.api.response.Topology;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.BrokerInfo;
+import io.camunda.client.api.response.Topology;
 import io.zeebe.containers.cluster.ZeebeCluster;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -60,7 +60,7 @@ final class ZeebeClusterWithEmbeddedGatewaysExampleTest {
     final Topology topology;
 
     // when
-    try (final ZeebeClient client = cluster.newClientBuilder().build()) {
+    try (final CamundaClient client = cluster.newClientBuilder().build()) {
       topology = client.newTopologyRequest().send().join(5, TimeUnit.SECONDS);
     }
 

--- a/core/src/test/java/io/zeebe/containers/examples/cluster/ZeebeClusterWithGatewayExampleTest.java
+++ b/core/src/test/java/io/zeebe/containers/examples/cluster/ZeebeClusterWithGatewayExampleTest.java
@@ -15,9 +15,9 @@
  */
 package io.zeebe.containers.examples.cluster;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.BrokerInfo;
-import io.camunda.zeebe.client.api.response.Topology;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.BrokerInfo;
+import io.camunda.client.api.response.Topology;
 import io.zeebe.containers.cluster.ZeebeCluster;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -61,7 +61,7 @@ final class ZeebeClusterWithGatewayExampleTest {
     final Topology topology;
 
     // when
-    try (final ZeebeClient client = cluster.newClientBuilder().build()) {
+    try (final CamundaClient client = cluster.newClientBuilder().build()) {
       topology = client.newTopologyRequest().send().join(5, TimeUnit.SECONDS);
     }
 

--- a/core/src/test/java/io/zeebe/containers/examples/exporter/BrokerWithDebugExporterIT.java
+++ b/core/src/test/java/io/zeebe/containers/examples/exporter/BrokerWithDebugExporterIT.java
@@ -17,7 +17,7 @@ package io.zeebe.containers.examples.exporter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.client.CamundaClient;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
@@ -68,7 +68,7 @@ final class BrokerWithDebugExporterIT {
   @Test
   void shouldReadExportedRecords() {
     // given
-    try (final ZeebeClient client = TestSupport.newZeebeClient(container)) {
+    try (final CamundaClient client = TestSupport.newZeebeClient(container)) {
 
       // when
       client

--- a/core/src/test/java/io/zeebe/containers/util/TestSupport.java
+++ b/core/src/test/java/io/zeebe/containers/util/TestSupport.java
@@ -15,7 +15,7 @@
  */
 package io.zeebe.containers.util;
 
-import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.client.CamundaClient;
 import io.zeebe.containers.ZeebeGatewayNode;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -57,8 +57,8 @@ public final class TestSupport {
   }
 
   /** Returns a client for the given gateway, using a plaintext connection. */
-  public static ZeebeClient newZeebeClient(final ZeebeGatewayNode<?> gateway) {
-    return ZeebeClient.newClientBuilder()
+  public static CamundaClient newZeebeClient(final ZeebeGatewayNode<?> gateway) {
+    return CamundaClient.newClientBuilder()
         .usePlaintext()
         .grpcAddress(gateway.getGrpcAddress())
         .restAddress(gateway.getRestAddress())

--- a/core/src/test/java/io/zeebe/containers/util/TopologyAssert.java
+++ b/core/src/test/java/io/zeebe/containers/util/TopologyAssert.java
@@ -15,9 +15,9 @@
  */
 package io.zeebe.containers.util;
 
-import io.camunda.zeebe.client.api.response.BrokerInfo;
-import io.camunda.zeebe.client.api.response.PartitionInfo;
-import io.camunda.zeebe.client.api.response.Topology;
+import io.camunda.client.api.response.BrokerInfo;
+import io.camunda.client.api.response.PartitionInfo;
+import io.camunda.client.api.response.Topology;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -60,7 +60,7 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-client-java</artifactId>
+      <artifactId>camunda-client-java</artifactId>
     </dependency>
 
     <dependency>

--- a/engine/src/main/java/io/zeebe/containers/engine/ZeebeClusterEngine.java
+++ b/engine/src/main/java/io/zeebe/containers/engine/ZeebeClusterEngine.java
@@ -16,9 +16,9 @@
 package io.zeebe.containers.engine;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.ZeebeClientBuilder;
-import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.CamundaClientBuilder;
+import io.camunda.client.impl.CamundaObjectMapper;
 import io.camunda.zeebe.process.test.api.RecordStreamSource;
 import io.zeebe.containers.ZeebeGatewayNode;
 import io.zeebe.containers.ZeebeNode;
@@ -42,7 +42,7 @@ import org.apiguardian.api.API.Status;
  */
 @API(status = Status.INTERNAL)
 final class ZeebeClusterEngine implements TestAwareContainerEngine {
-  private final List<ZeebeClient> clients = new ArrayList<>();
+  private final List<CamundaClient> clients = new ArrayList<>();
   private final DebugReceiverStream recordStream;
   private final ZeebeCluster cluster;
   private final Collection<ZeebeClock> clocks;
@@ -69,13 +69,13 @@ final class ZeebeClusterEngine implements TestAwareContainerEngine {
   }
 
   @Override
-  public ZeebeClient createClient() {
+  public CamundaClient createClient() {
     return createClient(UnaryOperator.identity());
   }
 
   @Override
-  public ZeebeClient createClient(final ObjectMapper customObjectMapper) {
-    return createClient(b -> b.withJsonMapper(new ZeebeObjectMapper(customObjectMapper)));
+  public CamundaClient createClient(final ObjectMapper customObjectMapper) {
+    return createClient(b -> b.withJsonMapper(new CamundaObjectMapper(customObjectMapper)));
   }
 
   @SuppressWarnings("deprecation")
@@ -115,15 +115,15 @@ final class ZeebeClusterEngine implements TestAwareContainerEngine {
     CloseHelper.closeAll(cluster, recordStream);
   }
 
-  private ZeebeClient createClient(final UnaryOperator<ZeebeClientBuilder> configurator) {
+  private CamundaClient createClient(final UnaryOperator<CamundaClientBuilder> configurator) {
     final ZeebeGatewayNode<?> gateway = cluster.getAvailableGateway();
-    final ZeebeClientBuilder builder =
+    final CamundaClientBuilder builder =
         configurator.apply(
-            ZeebeClient.newClientBuilder()
+            CamundaClient.newClientBuilder()
                 .usePlaintext()
                 .grpcAddress(gateway.getGrpcAddress())
                 .restAddress(gateway.getRestAddress()));
-    final ZeebeClient client = builder.build();
+    final CamundaClient client = builder.build();
     clients.add(client);
 
     return client;

--- a/engine/src/main/java/io/zeebe/containers/engine/ZeebeContainerEngine.java
+++ b/engine/src/main/java/io/zeebe/containers/engine/ZeebeContainerEngine.java
@@ -16,9 +16,9 @@
 package io.zeebe.containers.engine;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.ZeebeClientBuilder;
-import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.CamundaClientBuilder;
+import io.camunda.client.impl.CamundaObjectMapper;
 import io.camunda.zeebe.process.test.api.RecordStreamSource;
 import io.zeebe.containers.ZeebeBrokerNode;
 import io.zeebe.containers.ZeebeContainer;
@@ -43,7 +43,7 @@ import org.testcontainers.containers.GenericContainer;
 final class ZeebeContainerEngine<
         T extends GenericContainer<T> & ZeebeGatewayNode<T> & ZeebeBrokerNode<T>>
     implements TestAwareContainerEngine {
-  private final List<ZeebeClient> clients = new ArrayList<>();
+  private final List<CamundaClient> clients = new ArrayList<>();
   private final DebugReceiverStream recordStream;
   private final T container;
   private final ZeebeClock clock;
@@ -66,13 +66,13 @@ final class ZeebeContainerEngine<
   }
 
   @Override
-  public ZeebeClient createClient() {
+  public CamundaClient createClient() {
     return createClient(UnaryOperator.identity());
   }
 
   @Override
-  public ZeebeClient createClient(final ObjectMapper objectMapper) {
-    return createClient(b -> b.withJsonMapper(new ZeebeObjectMapper(objectMapper)));
+  public CamundaClient createClient(final ObjectMapper objectMapper) {
+    return createClient(b -> b.withJsonMapper(new CamundaObjectMapper(objectMapper)));
   }
 
   @SuppressWarnings("deprecation")
@@ -112,14 +112,14 @@ final class ZeebeContainerEngine<
     CloseHelper.closeAll(container, recordStream);
   }
 
-  private ZeebeClient createClient(final UnaryOperator<ZeebeClientBuilder> configurator) {
-    final ZeebeClientBuilder builder =
+  private CamundaClient createClient(final UnaryOperator<CamundaClientBuilder> configurator) {
+    final CamundaClientBuilder builder =
         configurator.apply(
-            ZeebeClient.newClientBuilder()
+            CamundaClient.newClientBuilder()
                 .usePlaintext()
                 .grpcAddress(container.getGrpcAddress())
                 .restAddress(container.getRestAddress()));
-    final ZeebeClient client = builder.build();
+    final CamundaClient client = builder.build();
     clients.add(client);
 
     return client;

--- a/engine/src/test/java/io/zeebe/containers/engine/ZeebeClusterEngineIT.java
+++ b/engine/src/test/java/io/zeebe/containers/engine/ZeebeClusterEngineIT.java
@@ -19,8 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.within;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.command.FinalCommandStep;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.zeebe.protocol.record.Record;
 import io.zeebe.containers.ZeebeGatewayNode;
 import io.zeebe.containers.clock.ZeebeClock;
@@ -70,7 +70,7 @@ final class ZeebeClusterEngineIT {
   @Test
   void shouldCloseEverythingOnStop() {
     // given
-    final ZeebeClient client;
+    final CamundaClient client;
     final InetSocketAddress receiverAddress;
     try (final ZeebeClusterEngine engine = new ZeebeClusterEngine(cluster, recordStream)) {
       engine.start();
@@ -107,7 +107,7 @@ final class ZeebeClusterEngineIT {
       // given
 
       // when
-      final ZeebeClient client = engine.createClient();
+      final CamundaClient client = engine.createClient();
 
       // then
       assertThat((Future<?>) client.newTopologyRequest().send())

--- a/engine/src/test/java/io/zeebe/containers/engine/ZeebeContainerEngineIT.java
+++ b/engine/src/test/java/io/zeebe/containers/engine/ZeebeContainerEngineIT.java
@@ -19,8 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.within;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.command.FinalCommandStep;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.zeebe.protocol.record.Record;
 import io.zeebe.containers.ZeebeContainer;
 import io.zeebe.containers.clock.ZeebeClock;
@@ -50,7 +50,7 @@ final class ZeebeContainerEngineIT {
   @Test
   void shouldCloseEverythingOnStop() {
     // given
-    final ZeebeClient client;
+    final CamundaClient client;
     final InetSocketAddress receiverAddress;
     try (final ZeebeContainerEngine<?> engine =
         new ZeebeContainerEngine<>(container, recordStream)) {
@@ -90,7 +90,7 @@ final class ZeebeContainerEngineIT {
       // given
 
       // when
-      final ZeebeClient client = engine.createClient();
+      final CamundaClient client = engine.createClient();
 
       // then
       assertThat((Future<?>) client.newTopologyRequest().send())

--- a/engine/src/test/java/io/zeebe/containers/engine/examples/ClusterEngineExampleIT.java
+++ b/engine/src/test/java/io/zeebe/containers/engine/examples/ClusterEngineExampleIT.java
@@ -15,8 +15,8 @@
  */
 package io.zeebe.containers.engine.examples;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.process.test.assertions.BpmnAssert;
@@ -62,7 +62,7 @@ final class ClusterEngineExampleIT {
     final ProcessInstanceEvent processInstance;
 
     // when
-    try (final ZeebeClient client = engine.createClient()) {
+    try (final CamundaClient client = engine.createClient()) {
       client.newDeployResourceCommand().addProcessModel(processModel, "process.bpmn").send().join();
       processInstance =
           client.newCreateInstanceCommand().bpmnProcessId("process").latestVersion().send().join();

--- a/engine/src/test/java/io/zeebe/containers/engine/examples/ContainerEngineExampleIT.java
+++ b/engine/src/test/java/io/zeebe/containers/engine/examples/ContainerEngineExampleIT.java
@@ -15,8 +15,8 @@
  */
 package io.zeebe.containers.engine.examples;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.process.test.assertions.BpmnAssert;
@@ -67,7 +67,7 @@ final class ContainerEngineExampleIT {
     final ProcessInstanceEvent processInstance;
 
     // when
-    try (final ZeebeClient client = engine.createClient()) {
+    try (final CamundaClient client = engine.createClient()) {
       client.newDeployResourceCommand().addProcessModel(processModel, "process.bpmn").send().join();
       processInstance =
           client.newCreateInstanceCommand().bpmnProcessId("process").latestVersion().send().join();

--- a/engine/src/test/java/io/zeebe/containers/engine/examples/GracePeriodExampleIT.java
+++ b/engine/src/test/java/io/zeebe/containers/engine/examples/GracePeriodExampleIT.java
@@ -15,8 +15,8 @@
  */
 package io.zeebe.containers.engine.examples;
 
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.process.test.assertions.BpmnAssert;
@@ -50,7 +50,7 @@ final class GracePeriodExampleIT {
     final ProcessInstanceEvent processInstance;
 
     // when
-    try (final ZeebeClient client = engine.createClient()) {
+    try (final CamundaClient client = engine.createClient()) {
       client.newDeployResourceCommand().addProcessModel(processModel, "process.bpmn").send().join();
       processInstance =
           client.newCreateInstanceCommand().bpmnProcessId("process").latestVersion().send().join();

--- a/justfile
+++ b/justfile
@@ -10,7 +10,7 @@ default:
 @build +mvnArgs='':
   ./mvnw install -DskipTests -DskipChecks -T1C {{ mvnArgs }}
 
-@rebuild: clean build
+@rebuild +mvnArgs='': clean build
 
 @lint +mvnArgs='':
   ./mvnw verify -DskipTests {{ mvnArgs }}

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <version.slf4j>2.0.16</version.slf4j>
     <version.testcontainers>1.20.4</version.testcontainers>
     <version.wiremock>3.10.0</version.wiremock>
-    <version.zeebe>8.7.0-SNAPSHOT</version.zeebe>
+    <version.zeebe>8.7.0-alpha3-rc1</version.zeebe>
 
     <!-- plugin version -->
     <plugin.version.checkstyle>3.6.0</plugin.version.checkstyle>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <version.slf4j>2.0.16</version.slf4j>
     <version.testcontainers>1.20.4</version.testcontainers>
     <version.wiremock>3.10.0</version.wiremock>
-    <version.zeebe>8.7.0-alpha3-rc1</version.zeebe>
+    <version.zeebe>8.7.0-alpha3-rc5</version.zeebe>
 
     <!-- plugin version -->
     <plugin.version.checkstyle>3.6.0</plugin.version.checkstyle>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <version.slf4j>2.0.16</version.slf4j>
     <version.testcontainers>1.20.4</version.testcontainers>
     <version.wiremock>3.10.0</version.wiremock>
-    <version.zeebe>8.6.7</version.zeebe>
+    <version.zeebe>8.7.0-SNAPSHOT</version.zeebe>
 
     <!-- plugin version -->
     <plugin.version.checkstyle>3.6.0</plugin.version.checkstyle>


### PR DESCRIPTION
## Description

This PR migrates `zeebe-process-test` to use Camunda 8.7.0, which has some breaking changes, notably the client migration (packages and class names changed).

This means this is also a breaking change, but it will be first released in 4.0.0.

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/camunda-cloud/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/camunda-cloud/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
- [x] Ensure all PR checks are green

