### PR TITLE
feat: disable API protections by default

### DIFF
--- a/core/src/main/java/io/zeebe/containers/ZeebeBrokerContainer.java
+++ b/core/src/main/java/io/zeebe/containers/ZeebeBrokerContainer.java
@@ -107,6 +107,7 @@ public class ZeebeBrokerContainer extends GenericContainer<ZeebeBrokerContainer>
         .withEnv("ZEEBE_BROKER_GATEWAY_ENABLE", "false")
         .withEnv("ZEEBE_BROKER_NETWORK_HOST", "0.0.0.0")
         .withEnv("ZEEBE_BROKER_NETWORK_ADVERTISEDHOST", getInternalHost())
+        .withEnv("CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI", "true")
         .addExposedPorts(
             ZeebePort.COMMAND.getPort(),
             ZeebePort.INTERNAL.getPort(),

--- a/core/src/main/java/io/zeebe/containers/ZeebeContainer.java
+++ b/core/src/main/java/io/zeebe/containers/ZeebeContainer.java
@@ -98,6 +98,7 @@ public class ZeebeContainer extends GenericContainer<ZeebeContainer>
         .withEnv("ZEEBE_BROKER_GATEWAY_ENABLE", "true")
         .withEnv("ZEEBE_BROKER_NETWORK_HOST", "0.0.0.0")
         .withEnv("ZEEBE_BROKER_NETWORK_ADVERTISEDHOST", getInternalHost())
+        .withEnv("CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI", "true")
         .addExposedPorts(
             ZeebePort.GATEWAY_REST.getPort(),
             ZeebePort.GATEWAY_GRPC.getPort(),

--- a/core/src/main/java/io/zeebe/containers/ZeebeGatewayContainer.java
+++ b/core/src/main/java/io/zeebe/containers/ZeebeGatewayContainer.java
@@ -114,6 +114,7 @@ public class ZeebeGatewayContainer extends GenericContainer<ZeebeGatewayContaine
         .withEnv("ZEEBE_GATEWAY_CLUSTER_MEMBERID", getInternalHost())
         .withEnv("ZEEBE_GATEWAY_CLUSTER_HOST", getInternalHost())
         .withEnv("ZEEBE_STANDALONE_GATEWAY", "true")
+        .withEnv("CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI", "true")
         .withStartupTimeout(DEFAULT_STARTUP_TIMEOUT)
         .addExposedPorts(
             ZeebePort.GATEWAY_REST.getPort(),


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

I happened to come across this library since we use it in our Zeebe tests as well. Figured I'd disable the API protections here by default as well.

## Related issues

<!-- Which issues are closed by this PR or are related -->

Related to https://github.com/camunda/camunda/issues/31903

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/camunda-cloud/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/camunda-cloud/zeebe/wiki/Code-Style)
- [ ] If submitting code, please run `mvn clean install -DskipTests` locally before committing
- [ ] Ensure all PR checks are green

