### PR TITLE
refactor: replace property CONTACTPOINT in favor of INITIALCONTACTPOINTS

### DIFF
--- a/core/src/main/java/io/zeebe/containers/cluster/ZeebeClusterBuilder.java
+++ b/core/src/main/java/io/zeebe/containers/cluster/ZeebeClusterBuilder.java
@@ -495,7 +495,8 @@ public class ZeebeClusterBuilder {
         gateway
             .dependsOn(contactPoint.self())
             .withEnv(
-                "ZEEBE_GATEWAY_CLUSTER_CONTACTPOINT", contactPoint.getInternalClusterAddress());
+                "ZEEBE_GATEWAY_CLUSTER_INITIALCONTACTPOINTS",
+                contactPoint.getInternalClusterAddress());
       }
     }
   }

--- a/core/src/test/java/io/zeebe/containers/ZeebeBrokerNodeTest.java
+++ b/core/src/test/java/io/zeebe/containers/ZeebeBrokerNodeTest.java
@@ -162,7 +162,8 @@ final class ZeebeBrokerNodeTest {
             new ZeebeGatewayContainer()
                 .withNetwork(NETWORK)
                 .withEnv(
-                    "ZEEBE_GATEWAY_CLUSTER_CONTACTPOINT", broker.getInternalClusterAddress())) {
+                    "ZEEBE_GATEWAY_CLUSTER_INITIALCONTACTPOINTS",
+                    broker.getInternalClusterAddress())) {
 
       // when
       broker.start();

--- a/core/src/test/java/io/zeebe/containers/ZeebeGatewayContainerTest.java
+++ b/core/src/test/java/io/zeebe/containers/ZeebeGatewayContainerTest.java
@@ -41,7 +41,8 @@ final class ZeebeGatewayContainerTest {
       new ZeebeGatewayContainer()
           .withNetwork(network)
           .withEnv(
-              "ZEEBE_GATEWAY_CLUSTER_CONTACTPOINT", brokerContainer.getInternalClusterAddress());
+              "ZEEBE_GATEWAY_CLUSTER_INITIALCONTACTPOINTS",
+              brokerContainer.getInternalClusterAddress());
 
   @AfterEach
   void afterEach() {

--- a/core/src/test/java/io/zeebe/containers/cluster/ZeebeClusterBuilderTest.java
+++ b/core/src/test/java/io/zeebe/containers/cluster/ZeebeClusterBuilderTest.java
@@ -455,8 +455,9 @@ final class ZeebeClusterBuilderTest {
         cluster.getGateways().values().iterator().next();
 
     assertThat(gateway.getEnvMap())
-        .as("the gateway has the correct broker contact point configured")
-        .containsEntry("ZEEBE_GATEWAY_CLUSTER_CONTACTPOINT", broker.getInternalClusterAddress());
+        .as("the gateway has the correct broker initial contact points configured")
+        .containsEntry(
+            "ZEEBE_GATEWAY_CLUSTER_INITIALCONTACTPOINTS", broker.getInternalClusterAddress());
   }
 
   @Test
@@ -473,8 +474,8 @@ final class ZeebeClusterBuilderTest {
         cluster.getGateways().values().iterator().next();
 
     assertThat(gateway.getEnvMap())
-        .as("the gateway has no contact point configured since there are no brokers")
-        .doesNotContainKey("ZEEBE_GATEWAY_CLUSTER_CONTACTPOINT");
+        .as("the gateway has no initial contact points configured since there are no brokers")
+        .doesNotContainKey("ZEEBE_GATEWAY_CLUSTER_INITIALCONTACTPOINTS");
   }
 
   @Test

--- a/core/src/test/java/io/zeebe/containers/examples/ClusterWithGatewayExampleTest.java
+++ b/core/src/test/java/io/zeebe/containers/examples/ClusterWithGatewayExampleTest.java
@@ -56,7 +56,8 @@ final class ClusterWithGatewayExampleTest {
   private final ZeebeGatewayContainer gatewayContainer =
       new ZeebeGatewayContainer()
           .withEnv(
-              "ZEEBE_GATEWAY_CLUSTER_CONTACTPOINT", brokerZeroContainer.getInternalClusterAddress())
+              "ZEEBE_GATEWAY_CLUSTER_INITIALCONTACTPOINTS",
+              brokerZeroContainer.getInternalClusterAddress())
           .withNetwork(network)
           .withTopologyCheck(
               new ZeebeTopologyWaitStrategy().forBrokersCount(3).forReplicationFactor(3));


### PR DESCRIPTION
## Description

This PR replaces the deprecated property ZEEBE_GATEWAY_CLUSTER_CONTACTPOINT with ZEEBE_GATEWAY_CLUSTER_INITIALCONTACTPOINTS.

## Related issues

closes https://github.com/camunda-community-hub/zeebe-test-container/issues/992

## Pull Request Checklist

- [x] All commit messages match our [commit message guidelines](https://github.com/camunda-cloud/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [x] The submitting code follows our [code style](https://github.com/camunda-cloud/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
- [ ] Ensure all PR checks are green

